### PR TITLE
'refund_transaction' for order response with test

### DIFF
--- a/Source/Coinbase.Tests/IntegrationTests.cs
+++ b/Source/Coinbase.Tests/IntegrationTests.cs
@@ -10,6 +10,9 @@ namespace Coinbase.Tests
     [TestFixture]
     public class IntegrationTests
     {
+        private const string ApiKey = "my_api_key";
+        private const string ApiSecretKey = "my_secret_key";
+
         [Test]
         [Explicit]
         public void integration_test_create_button()
@@ -93,7 +96,7 @@ namespace Coinbase.Tests
         public void create_refund_test()
         {
             // arrange
-            var api = new CoinbaseApi(apiKey: "my_api_key", apiSecret: "my_api_secret");
+            var api = new CoinbaseApi(apiKey: ApiKey, apiSecret: ApiSecretKey);
 
             var refundOptions = new RefundOptions
                 {
@@ -132,7 +135,7 @@ namespace Coinbase.Tests
         public void send_money_test()
         {
             // arrange
-            var api = new CoinbaseApi(apiKey: "my_api_key", apiSecret: "my_api_secret");
+            var api = new CoinbaseApi(apiKey: ApiKey, apiSecret: ApiSecretKey);
 
             //Make a direct payment of BTC to another
             //bit coin address
@@ -182,7 +185,7 @@ namespace Coinbase.Tests
         public void get_order_test()
         {
             // arrange
-            var api = new CoinbaseApi(apiKey: "my_api_key", apiSecret: "my_api_secret");
+            var api = new CoinbaseApi(apiKey: ApiKey, apiSecret: ApiSecretKey);
 
             // act
             var orderResult = api.GetOrder("ORDER_ID_OR_CUSTOM");
@@ -199,6 +202,30 @@ namespace Coinbase.Tests
 
             // assert
             orderResult.Order.Should().NotBeNull();
+        }
+
+        [Test]
+        [Explicit]
+        public void get_order_with_refund_test()
+        {
+            // arrange
+            var api = new CoinbaseApi(apiKey: ApiKey, apiSecret: ApiSecretKey);
+
+            // act
+            var orderResult = api.GetOrder("ORDER_ID_OR_CUSTOM");
+
+            if (orderResult.Error != null)
+            {
+                //Some Error
+            }
+            else if (orderResult.Order.Status == Status.Completed)
+            {
+                //The request was successful
+                var orderTxn = orderResult.Order;
+            }
+
+            // assert
+            orderResult.Order.RefundTransaction.Should().NotBeNull();
         }
     }
 }

--- a/Source/Coinbase/ObjectModel/Order.cs
+++ b/Source/Coinbase/ObjectModel/Order.cs
@@ -28,6 +28,9 @@ namespace Coinbase.ObjectModel
 
         public Transaction Transaction { get; set; }
 
+        [JsonProperty("refund_transaction")]
+        public Transaction RefundTransaction { get; set; }
+
         public Customer Customer { get; set; }
     }
 }


### PR DESCRIPTION
Adds a 'refund_transaction' section that comes back in a response that has a refund. 

This is useful for checking the status of an order that has been refunded. The order remains as 'complete' but it may have a refund transaction, this checks that it has such. 
