### PR TITLE
Adding Support For OAuth

### DIFF
--- a/Source/Coinbase.Tests/ApiTest.cs
+++ b/Source/Coinbase.Tests/ApiTest.cs
@@ -9,7 +9,7 @@ namespace Coinbase.Tests
       [Test]
       public void ConstructorTests()
       {
-         var options = new CoinbaseApiOptions { ApiKey = "0CCAA858-2625-4652-A781-9BF48A3E7635", ApiSecret = "7DC36573-3C21-4783-AC17-1687AFAFB8C9" };
+         var options = new CoinbaseApiOptions("0CCAA858-2625-4652-A781-9BF48A3E7635", "7DC36573-3C21-4783-AC17-1687AFAFB8C9");
          var api = new CoinbaseApi(options);
 
          api.apiKey.Should().Be("0CCAA858-2625-4652-A781-9BF48A3E7635");

--- a/Source/Coinbase.Tests/ApiTest.cs
+++ b/Source/Coinbase.Tests/ApiTest.cs
@@ -9,7 +9,8 @@ namespace Coinbase.Tests
       [Test]
       public void ConstructorTests()
       {
-         var api = new CoinbaseApi("0CCAA858-2625-4652-A781-9BF48A3E7635", "7DC36573-3C21-4783-AC17-1687AFAFB8C9", useSandbox: false, proxy: null);
+         var options = new CoinbaseApiOptions { ApiKey = "0CCAA858-2625-4652-A781-9BF48A3E7635", ApiSecret = "7DC36573-3C21-4783-AC17-1687AFAFB8C9" };
+         var api = new CoinbaseApi(options);
 
          api.apiKey.Should().Be("0CCAA858-2625-4652-A781-9BF48A3E7635");
          api.apiSecret.Should().Be("7DC36573-3C21-4783-AC17-1687AFAFB8C9");
@@ -17,7 +18,8 @@ namespace Coinbase.Tests
          api.apiUrl.Should().Be(CoinbaseConstants.LiveApiUrl);
          api.apiCheckoutUrl.Should().Be(CoinbaseConstants.LiveCheckoutUrl);
 
-         var api2 = new CoinbaseApi("0CCAA858-2625-4652-A781-9BF48A3E7635", "7DC36573-3C21-4783-AC17-1687AFAFB8C9", useSandbox: true, proxy: null);
+         options.UseSandbox = true;
+         var api2 = new CoinbaseApi(options);
 
          api2.apiUrl.Should().Be(CoinbaseConstants.TestApiUrl);
          api2.apiCheckoutUrl.Should().Be(CoinbaseConstants.TestCheckoutUrl);

--- a/Source/Coinbase.Tests/IntegrationTests.cs
+++ b/Source/Coinbase.Tests/IntegrationTests.cs
@@ -10,111 +10,129 @@ using RestSharp;
 
 namespace Coinbase.Tests
 {
-   [TestFixture]
-   public class IntegrationTests
-   {
-      private const string ApiKey = "l09yJNB38UjpU3eh";
-      private const string ApiSecretKey = "0l1EfqtS5mRSt3tnpDJZW2umOdjIJaE7";
-      private WebProxy proxy = new WebProxy("http://localhost.:8888", false);
+    [TestFixture]
+    public class IntegrationTests
+    {
+        private const string ApiKey = "l09yJNB38UjpU3eh";
+        private const string ApiSecretKey = "0l1EfqtS5mRSt3tnpDJZW2umOdjIJaE7";
+        private WebProxy proxy = new WebProxy("http://localhost.:8888", false);
 
-      [Test]
-      [Explicit]
-      public void create_customer_checkout()
-      {
-         var api = new CoinbaseApi(ApiKey, ApiSecretKey, useSandbox: true, proxy: proxy, useTimeApi: true);
+        [Test]
+        [Explicit]
+        public void create_customer_checkout()
+        {
+            var apiOptions = this.GetDefaultCoinbaseApiOptions();
+            var api = new CoinbaseApi(apiOptions);
 
-         var purchaseId = Guid.NewGuid().ToString("n");
+            var purchaseId = Guid.NewGuid().ToString("n");
 
-         var request = new CheckoutRequest
+            var request = new CheckoutRequest
             {
-               Amount = 10.00m,
-               Currency = "USD",
-               Name = "Test Order",
-               Metadata =
+                Amount = 10.00m,
+                Currency = "USD",
+                Name = "Test Order",
+                Metadata =
                   {
                      {"purchaseId", purchaseId}
                   },
-               NotificationsUrl = ""
+                NotificationsUrl = ""
             };
 
-         request.Dump();
+            request.Dump();
 
-         var checkout = api.CreateCheckout(request);
+            var checkout = api.CreateCheckout(request);
 
-         checkout.Dump();
-         if( checkout.Errors?.Length == 0 )
-         {
-            var redirectUrl = api.GetCheckoutUrl(checkout);
-            //do redirect with redirectUrl
-         }
-         else
-         {
-            //Error making checkout page.
-         }
-
-         var checkoutUrl = api.GetCheckoutUrl(checkout);
-         checkoutUrl.Should().StartWith("https://sandbox.coinbase.com/checkouts");
-      }
-
-      [Test]
-      [Explicit]
-      public void refund_example()
-      {
-         var api = new CoinbaseApi(ApiKey, ApiSecretKey, useSandbox: true, proxy: proxy, useTimeApi: true);
-
-         var options = new
+            checkout.Dump();
+            if (checkout.Errors?.Length == 0)
             {
-               currency = "BTC"
+                var redirectUrl = api.GetCheckoutUrl(checkout);
+                //do redirect with redirectUrl
+            }
+            else
+            {
+                //Error making checkout page.
+            }
+
+            var checkoutUrl = api.GetCheckoutUrl(checkout);
+            checkoutUrl.Should().StartWith("https://sandbox.coinbase.com/checkouts");
+        }
+
+        [Test]
+        [Explicit]
+        public void refund_example()
+        {
+            var apiOptions = this.GetDefaultCoinbaseApiOptions();
+            var api = new CoinbaseApi(apiOptions);
+
+            var options = new
+            {
+                currency = "BTC"
             };
 
-         var orderId = "ORDER_ID_HERE";
+            var orderId = "ORDER_ID_HERE";
 
-         var response = api.SendRequest($"/orders/{orderId}/refund", options);
-         //process response as needed
-      }
+            var response = api.SendRequest($"/orders/{orderId}/refund", options);
+            //process response as needed
+        }
 
 
-      [Test]
-      public void test_callback_verification()
-      {
-         var json =
-            @"{""order"":{""id"":null,""uuid"":""54b2d0f8-2bb8-5771-b330-9366ac079d60"",""resource_path"":""/v2/orders/54b2d0f8-2bb8-5771-b330-9366ac079d60"",""metadata"":null,""created_at"":null,""status"":""completed"",""event"":null,""total_btc"":{""cents"":100000000.0,""currency_iso"":""BTC""},""total_native"":{""cents"":1000000.0,""currency_iso"":""USD""},""total_payout"":{""cents"":1000000.0,""currency_iso"":""USD""},""custom"":""123456789"",""receive_address"":""mpAWHN5o3PtqQbu2WFsGgwx6Zep9pHoMyp"",""button"":{""type"":""buy_now"",""subscription"":false,""repeat"":null,""name"":""Test Item"",""description"":null,""id"":null,""uuid"":""ad92ae20-be4b-523d-aac6-6ff14ac2cc21"",""resource_path"":""/v2/checkouts/ad92ae20-be4b-523d-aac6-6ff14ac2cc21""},""transaction"":{""id"":""566656b6804ce90001003b2a"",""hash"":""4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"",""confirmations"":0}}}";
+        [Test]
+        public void test_callback_verification()
+        {
+            var json =
+               @"{""order"":{""id"":null,""uuid"":""54b2d0f8-2bb8-5771-b330-9366ac079d60"",""resource_path"":""/v2/orders/54b2d0f8-2bb8-5771-b330-9366ac079d60"",""metadata"":null,""created_at"":null,""status"":""completed"",""event"":null,""total_btc"":{""cents"":100000000.0,""currency_iso"":""BTC""},""total_native"":{""cents"":1000000.0,""currency_iso"":""USD""},""total_payout"":{""cents"":1000000.0,""currency_iso"":""USD""},""custom"":""123456789"",""receive_address"":""mpAWHN5o3PtqQbu2WFsGgwx6Zep9pHoMyp"",""button"":{""type"":""buy_now"",""subscription"":false,""repeat"":null,""name"":""Test Item"",""description"":null,""id"":null,""uuid"":""ad92ae20-be4b-523d-aac6-6ff14ac2cc21"",""resource_path"":""/v2/checkouts/ad92ae20-be4b-523d-aac6-6ff14ac2cc21""},""transaction"":{""id"":""566656b6804ce90001003b2a"",""hash"":""4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"",""confirmations"":0}}}";
 
-         //X-Signature: qj7s3QLVlzkqrJdvH556ZvoM2dgeEwpXzkF0YPN4AR9GKL/F9kLcBmUarapMBAE5ef/QDcxN3ta8dBaTC1KYz+04+SriqvnuZzC3EXX5ksvxpN+i+6JjPIKsU63l1bk+t7GQvKeEGrq3/Al1OklVj9IMUnK5Sz59eUIByWgWBtVS0U+zI7ijwOoSZxkcAdY7l+EWa4t/W8gOChtA/2vdSgqtAVW/GcUMZ1ZFsH1U/EJIsY5Xw4dAbwtavIvABBBlmUTWUvj5Wubp7MaIptFfAL6fU1YwmbnsaKn6L+c4fTNsbOLCLYY7Czb4Um0MQ+A2/w1Ldwv2L9ie1b956y3lnbU/8qn6q0AU3FYOgepwmvoNRaca/ZXVniVZsY3PSX/zHf3WCjDh+jvAO6vneVpBlNNIyJjgGNzGdQzxzOhXJu5cFXJa1zXcPgELHtFSE2raG0tIdgwlgJwiYCls77R+3iMMv8CPat3a/GQ61Cax0Gsi80NaiavCgWjpMbXYRZvNP3DdUNVOvucIrtSWydq6bccQTamLCMpQ8fjB2zGcDglIl0I+W/6gtY1MflZ+ZmUySgEEww4PXlySYivvFwc/jpcptQ2vLXNjMZQmf9kbiRBe8PT/tpPUchUxNYzADDpSWeqBid0Jm7Um8G8zLwtBo5R1hHME9Gd/v3DOUk5sMzk=
-         var signature =
-            "qj7s3QLVlzkqrJdvH556ZvoM2dgeEwpXzkF0YPN4AR9GKL/F9kLcBmUarapMBAE5ef/QDcxN3ta8dBaTC1KYz+04+SriqvnuZzC3EXX5ksvxpN+i+6JjPIKsU63l1bk+t7GQvKeEGrq3/Al1OklVj9IMUnK5Sz59eUIByWgWBtVS0U+zI7ijwOoSZxkcAdY7l+EWa4t/W8gOChtA/2vdSgqtAVW/GcUMZ1ZFsH1U/EJIsY5Xw4dAbwtavIvABBBlmUTWUvj5Wubp7MaIptFfAL6fU1YwmbnsaKn6L+c4fTNsbOLCLYY7Czb4Um0MQ+A2/w1Ldwv2L9ie1b956y3lnbU/8qn6q0AU3FYOgepwmvoNRaca/ZXVniVZsY3PSX/zHf3WCjDh+jvAO6vneVpBlNNIyJjgGNzGdQzxzOhXJu5cFXJa1zXcPgELHtFSE2raG0tIdgwlgJwiYCls77R+3iMMv8CPat3a/GQ61Cax0Gsi80NaiavCgWjpMbXYRZvNP3DdUNVOvucIrtSWydq6bccQTamLCMpQ8fjB2zGcDglIl0I+W/6gtY1MflZ+ZmUySgEEww4PXlySYivvFwc/jpcptQ2vLXNjMZQmf9kbiRBe8PT/tpPUchUxNYzADDpSWeqBid0Jm7Um8G8zLwtBo5R1hHME9Gd/v3DOUk5sMzk=";
+            //X-Signature: qj7s3QLVlzkqrJdvH556ZvoM2dgeEwpXzkF0YPN4AR9GKL/F9kLcBmUarapMBAE5ef/QDcxN3ta8dBaTC1KYz+04+SriqvnuZzC3EXX5ksvxpN+i+6JjPIKsU63l1bk+t7GQvKeEGrq3/Al1OklVj9IMUnK5Sz59eUIByWgWBtVS0U+zI7ijwOoSZxkcAdY7l+EWa4t/W8gOChtA/2vdSgqtAVW/GcUMZ1ZFsH1U/EJIsY5Xw4dAbwtavIvABBBlmUTWUvj5Wubp7MaIptFfAL6fU1YwmbnsaKn6L+c4fTNsbOLCLYY7Czb4Um0MQ+A2/w1Ldwv2L9ie1b956y3lnbU/8qn6q0AU3FYOgepwmvoNRaca/ZXVniVZsY3PSX/zHf3WCjDh+jvAO6vneVpBlNNIyJjgGNzGdQzxzOhXJu5cFXJa1zXcPgELHtFSE2raG0tIdgwlgJwiYCls77R+3iMMv8CPat3a/GQ61Cax0Gsi80NaiavCgWjpMbXYRZvNP3DdUNVOvucIrtSWydq6bccQTamLCMpQ8fjB2zGcDglIl0I+W/6gtY1MflZ+ZmUySgEEww4PXlySYivvFwc/jpcptQ2vLXNjMZQmf9kbiRBe8PT/tpPUchUxNYzADDpSWeqBid0Jm7Um8G8zLwtBo5R1hHME9Gd/v3DOUk5sMzk=
+            var signature =
+               "qj7s3QLVlzkqrJdvH556ZvoM2dgeEwpXzkF0YPN4AR9GKL/F9kLcBmUarapMBAE5ef/QDcxN3ta8dBaTC1KYz+04+SriqvnuZzC3EXX5ksvxpN+i+6JjPIKsU63l1bk+t7GQvKeEGrq3/Al1OklVj9IMUnK5Sz59eUIByWgWBtVS0U+zI7ijwOoSZxkcAdY7l+EWa4t/W8gOChtA/2vdSgqtAVW/GcUMZ1ZFsH1U/EJIsY5Xw4dAbwtavIvABBBlmUTWUvj5Wubp7MaIptFfAL6fU1YwmbnsaKn6L+c4fTNsbOLCLYY7Czb4Um0MQ+A2/w1Ldwv2L9ie1b956y3lnbU/8qn6q0AU3FYOgepwmvoNRaca/ZXVniVZsY3PSX/zHf3WCjDh+jvAO6vneVpBlNNIyJjgGNzGdQzxzOhXJu5cFXJa1zXcPgELHtFSE2raG0tIdgwlgJwiYCls77R+3iMMv8CPat3a/GQ61Cax0Gsi80NaiavCgWjpMbXYRZvNP3DdUNVOvucIrtSWydq6bccQTamLCMpQ8fjB2zGcDglIl0I+W/6gtY1MflZ+ZmUySgEEww4PXlySYivvFwc/jpcptQ2vLXNjMZQmf9kbiRBe8PT/tpPUchUxNYzADDpSWeqBid0Jm7Um8G8zLwtBo5R1hHME9Gd/v3DOUk5sMzk=";
 
-         var api = new CoinbaseApi(ApiKey, ApiSecretKey, useSandbox: true, proxy: proxy, useTimeApi: true);
+            var apiOptions = this.GetDefaultCoinbaseApiOptions();
+            var api = new CoinbaseApi(apiOptions);
 
-         var note = JsonConvert.DeserializeObject<Notification>(json, api.JsonSettings);
+            var note = JsonConvert.DeserializeObject<Notification>(json, api.JsonSettings);
 
-         //            note.IsVerified.Should().BeFalse();
-         note.IsVerified.Should().BeFalse();
+            //            note.IsVerified.Should().BeFalse();
+            note.IsVerified.Should().BeFalse();
 
-         //api.VerifyNotification(json, signature)
-         //    .Should().BeTrue();
-      }
+            //api.VerifyNotification(json, signature)
+            //    .Should().BeTrue();
+        }
 
-      [Test]
-      [Explicit]
-      public void can_list_orders()
-      {
-         var api = new CoinbaseApi(ApiKey, ApiSecretKey, useSandbox: true, proxy: proxy, useTimeApi: true);
+        [Test]
+        [Explicit]
+        public void can_list_orders()
+        {
+            var apiOptions = this.GetDefaultCoinbaseApiOptions();
+            var api = new CoinbaseApi(apiOptions);
 
-         var response = api.SendRequest("orders", null, Method.GET);
+            var response = api.SendRequest("orders", null, Method.GET);
 
-         response.Dump();
-      }
+            response.Dump();
+        }
 
-      [Test]
-      public void can_deser_list_response()
-      {
-         var json =
-            @"{""pagination"":{""ending_before"":null,""starting_after"":null,""limit"":25,""order"":""desc"",""previous_uri"":null,""next_uri"":null},""data"":[{""id"":""cca4ac42-7db1-51b9-bad6-73553ca341b9"",""code"":""W020I6OB"",""type"":""order"",""name"":""Test Order"",""description"":null,""amount"":{""amount"":""10.00"",""currency"":""USD""},""receipt_url"":""https://www.coinbase.com/orders/2a9419b5e6258059bc52dfb9cfd0b08f/receipt"",""resource"":""order"",""resource_path"":""/v2/orders/cca4ac42-7db1-51b9-bad6-73553ca341b9"",""status"":""expired"",""bitcoin_amount"":{""amount"":""0.00100000"",""currency"":""BTC""},""payout_amount"":null,""bitcoin_address"":""n2hEf3xgQ9gLSUrYy8ZCP2Zw8TFyboqRk3"",""refund_address"":null,""bitcoin_uri"":""bitcoin:n2hEf3xgQ9gLSUrYy8ZCP2Zw8TFyboqRk3?amount=0.001\u0026r=https://sandbox.coinbase.com/r/56664c7b27aee501d2000057"",""notifications_url"":null,""paid_at"":null,""mispaid_at"":null,""expires_at"":""2015-12-08T03:35:27Z"",""metadata"":{},""created_at"":""2015-12-08T03:20:27Z"",""updated_at"":""2015-12-08T03:20:27Z"",""customer_info"":null,""transaction"":null,""mispayments"":[],""refunds"":[]},{""id"":""7e1d9170-cc8b-5468-ba7f-a852759854f8"",""code"":""B4K9P5ZL"",""type"":""order"",""name"":""Test Order"",""description"":null,""amount"":{""amount"":""10.00"",""currency"":""USD""},""receipt_url"":""https://www.coinbase.com/orders/bf6b871ba37ed6332e77a19d3c556544/receipt"",""resource"":""order"",""resource_path"":""/v2/orders/7e1d9170-cc8b-5468-ba7f-a852759854f8"",""status"":""expired"",""bitcoin_amount"":{""amount"":""0.00100000"",""currency"":""BTC""},""payout_amount"":null,""bitcoin_address"":""n1Cn2gwP674dau9D459bh29xsYY3EkPP1g"",""refund_address"":null,""bitcoin_uri"":""bitcoin:n1Cn2gwP674dau9D459bh29xsYY3EkPP1g?amount=0.001\u0026r=https://sandbox.coinbase.com/r/566649e04d3af201f800001f"",""notifications_url"":null,""paid_at"":null,""mispaid_at"":null,""expires_at"":""2015-12-08T03:24:20Z"",""metadata"":{},""created_at"":""2015-12-08T03:09:20Z"",""updated_at"":""2015-12-08T03:09:20Z"",""customer_info"":null,""transaction"":null,""mispayments"":[],""refunds"":[]}]}";
+        [Test]
+        public void can_deser_list_response()
+        {
+            var json =
+               @"{""pagination"":{""ending_before"":null,""starting_after"":null,""limit"":25,""order"":""desc"",""previous_uri"":null,""next_uri"":null},""data"":[{""id"":""cca4ac42-7db1-51b9-bad6-73553ca341b9"",""code"":""W020I6OB"",""type"":""order"",""name"":""Test Order"",""description"":null,""amount"":{""amount"":""10.00"",""currency"":""USD""},""receipt_url"":""https://www.coinbase.com/orders/2a9419b5e6258059bc52dfb9cfd0b08f/receipt"",""resource"":""order"",""resource_path"":""/v2/orders/cca4ac42-7db1-51b9-bad6-73553ca341b9"",""status"":""expired"",""bitcoin_amount"":{""amount"":""0.00100000"",""currency"":""BTC""},""payout_amount"":null,""bitcoin_address"":""n2hEf3xgQ9gLSUrYy8ZCP2Zw8TFyboqRk3"",""refund_address"":null,""bitcoin_uri"":""bitcoin:n2hEf3xgQ9gLSUrYy8ZCP2Zw8TFyboqRk3?amount=0.001\u0026r=https://sandbox.coinbase.com/r/56664c7b27aee501d2000057"",""notifications_url"":null,""paid_at"":null,""mispaid_at"":null,""expires_at"":""2015-12-08T03:35:27Z"",""metadata"":{},""created_at"":""2015-12-08T03:20:27Z"",""updated_at"":""2015-12-08T03:20:27Z"",""customer_info"":null,""transaction"":null,""mispayments"":[],""refunds"":[]},{""id"":""7e1d9170-cc8b-5468-ba7f-a852759854f8"",""code"":""B4K9P5ZL"",""type"":""order"",""name"":""Test Order"",""description"":null,""amount"":{""amount"":""10.00"",""currency"":""USD""},""receipt_url"":""https://www.coinbase.com/orders/bf6b871ba37ed6332e77a19d3c556544/receipt"",""resource"":""order"",""resource_path"":""/v2/orders/7e1d9170-cc8b-5468-ba7f-a852759854f8"",""status"":""expired"",""bitcoin_amount"":{""amount"":""0.00100000"",""currency"":""BTC""},""payout_amount"":null,""bitcoin_address"":""n1Cn2gwP674dau9D459bh29xsYY3EkPP1g"",""refund_address"":null,""bitcoin_uri"":""bitcoin:n1Cn2gwP674dau9D459bh29xsYY3EkPP1g?amount=0.001\u0026r=https://sandbox.coinbase.com/r/566649e04d3af201f800001f"",""notifications_url"":null,""paid_at"":null,""mispaid_at"":null,""expires_at"":""2015-12-08T03:24:20Z"",""metadata"":{},""created_at"":""2015-12-08T03:09:20Z"",""updated_at"":""2015-12-08T03:09:20Z"",""customer_info"":null,""transaction"":null,""mispayments"":[],""refunds"":[]}]}";
 
-         var obj = JsonConvert.DeserializeObject<CoinbaseResponse>(json);
+            var obj = JsonConvert.DeserializeObject<CoinbaseResponse>(json);
 
-         obj.Dump();
-      }
-   }
+            obj.Dump();
+        }
+
+        protected CoinbaseApiOptions GetDefaultCoinbaseApiOptions()
+        {
+            var apiOptions = new CoinbaseApiOptions
+            {
+                ApiKey = ApiKey,
+                ApiSecret = ApiSecretKey,
+                UseSandbox = true,
+                Proxy = proxy,
+                UseTimeApi = true
+            };
+
+            return apiOptions;
+        }
+    }
 }

--- a/Source/Coinbase.Tests/IntegrationTests.cs
+++ b/Source/Coinbase.Tests/IntegrationTests.cs
@@ -123,16 +123,7 @@ namespace Coinbase.Tests
 
         protected CoinbaseApiOptions GetDefaultCoinbaseApiOptions()
         {
-            var apiOptions = new CoinbaseApiOptions
-            {
-                ApiKey = ApiKey,
-                ApiSecret = ApiSecretKey,
-                UseSandbox = true,
-                Proxy = proxy,
-                UseTimeApi = true
-            };
-
-            return apiOptions;
+            return new CoinbaseApiOptions(ApiKey, ApiSecretKey, useSandbox: true, proxy: proxy, useTimeApi: true);
         }
     }
 }

--- a/Source/Coinbase/CoinbaseApi.cs
+++ b/Source/Coinbase/CoinbaseApi.cs
@@ -11,224 +11,106 @@ using RestSharp.Authenticators;
 
 namespace Coinbase
 {
-   public static class CoinbaseConstants
-   {
-      public const string LiveApiUrl = "https://api.coinbase.com/v2/";
-      public const string TestApiUrl = "https://api.sandbox.coinbase.com/v2/";
-      public const string LiveCheckoutUrl = "https://coinbase.com/checkouts/{code}";
-      public const string TestCheckoutUrl = "https://sandbox.coinbase.com/checkouts/{code}";
-      public const string ApiVersionDate = "2015-11-17";
-   }
+    public static class CoinbaseConstants
+    {
+        public const string LiveApiUrl = "https://api.coinbase.com/v2/";
+        public const string TestApiUrl = "https://api.sandbox.coinbase.com/v2/";
+        public const string LiveCheckoutUrl = "https://coinbase.com/checkouts/{code}";
+        public const string TestCheckoutUrl = "https://sandbox.coinbase.com/checkouts/{code}";
+        public const string ApiVersionDate = "2015-11-17";
+        public const string CBVersionHeader = "CB-VERSION";
+    }
 
-   public class CoinbaseApi
-   {
-      internal readonly string apiKey;
-      internal readonly string apiSecret;
-      internal readonly string apiUrl;
-      internal readonly string apiCheckoutUrl;
-      internal readonly WebProxy proxy;
+    public class CoinbaseApi : CoinbaseApiBase
+    {
+        internal readonly string apiKey;
+        internal readonly string apiSecret;
+        internal readonly string apiCheckoutUrl;
 
-      public JsonSerializerSettings JsonSettings = new JsonSerializerSettings
-         {
-            DefaultValueHandling = DefaultValueHandling.Ignore,
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-         };
+        private bool useTimeApi;
 
-      private bool useTimeApi;
+        /// <summary>
+        /// The main class for making Coinbase API calls.
+        /// </summary>
+        public CoinbaseApi(CoinbaseApiOptions options) : base(options)
+        {
+            //Issue #11 -- Check .NET's SecurityProtocol compatibility with Coinbase API Server
+            //
+            //For now, we'll keep this disabled until we know more. About the proper way to deal with SSL3
+            //
+            //if( ServicePointManager.SecurityProtocol == SecurityProtocolType.Ssl3 )
+            //{
+            //    throw new NotSupportedException(
+            //        "ServicePointManager.SecurityProtocol is set to SSL3 which is not supported by Coinbase API Servers. Please configure ServicePointManager.SecurityProtocol to another value like TLS in your application startup. More information here: https://github.com/bchavez/Coinbase/issues/11");
+            //}
 
-      /// <summary>
-      /// The main class for making Coinbase API calls.
-      /// </summary>
-      /// <param name="apiKey">Your API key</param>
-      /// <param name="apiSecret">Your API secret</param>
-      /// <param name="useTimeApi">Use Coinbase's Time API in signing requests. Results in 2 requests per call 
-      /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
-      /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
-      /// https://developers.coinbase.com/api/v2#api-key </param>
-      public CoinbaseApi(string apiKey = "", string apiSecret = "", bool useSandbox = false, WebProxy proxy = null, bool useTimeApi = true) :
-         this(apiKey, apiSecret, null, null, useTimeApi, proxy)
-      {
-         if( useSandbox )
-         {
-            this.apiUrl = CoinbaseConstants.TestApiUrl;
-            this.apiCheckoutUrl = CoinbaseConstants.TestCheckoutUrl;
-         }
-      }
-
-      /// <summary>
-      /// The main class for making Coinbase API calls.
-      /// </summary>
-      /// <param name="apiKey">Your API Key</param>
-      /// <param name="apiSecret">Your API Secret </param>
-      /// <param name="customApiEndpoint">A custom URL endpoint. Typically, you'd use this if you want to use the sandbox URL.</param>
-      /// <param name="useTimeApi">Use Coinbase's Time API in signing requests. Results in 2 requests per call 
-      /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
-      /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
-      /// https://developers.coinbase.com/api/v2#api-key </param>
-      public CoinbaseApi(
-         string apiKey,
-         string apiSecret,
-         string apiUrl = CoinbaseConstants.LiveApiUrl,
-         string checkoutUrl = CoinbaseConstants.LiveCheckoutUrl,
-         bool useTimeApi = true,
-         WebProxy proxy = null)
-      {
-         //Issue #11 -- Check .NET's SecurityProtocol compatibility with Coinbase API Server
-         //
-         //For now, we'll keep this disabled until we know more. About the proper way to deal with SSL3
-         //
-         //if( ServicePointManager.SecurityProtocol == SecurityProtocolType.Ssl3 )
-         //{
-         //    throw new NotSupportedException(
-         //        "ServicePointManager.SecurityProtocol is set to SSL3 which is not supported by Coinbase API Servers. Please configure ServicePointManager.SecurityProtocol to another value like TLS in your application startup. More information here: https://github.com/bchavez/Coinbase/issues/11");
-         //}
-         if( string.IsNullOrWhiteSpace(apiKey) ) throw new ArgumentException("The API key must be specified.", nameof(apiKey));
-         if( string.IsNullOrWhiteSpace(apiSecret) ) throw new ArgumentException("The API secret must be specified.", nameof(apiSecret));
-
-         this.apiKey = apiKey;
-         this.apiSecret = apiSecret;
-
-         this.apiUrl = !string.IsNullOrWhiteSpace(apiUrl) ? apiUrl : CoinbaseConstants.LiveApiUrl;
-         this.apiCheckoutUrl = !string.IsNullOrWhiteSpace(checkoutUrl) ? checkoutUrl : CoinbaseConstants.LiveCheckoutUrl;
-
-         this.proxy = proxy;
-         this.useTimeApi = useTimeApi;
-      }
-
-      protected virtual RestClient CreateClient()
-      {
-         var client = new RestClient(apiUrl)
+            if (options.UseSandbox)
             {
-               Proxy = this.proxy,
-               Authenticator = GetAuthenticator()
-            };
-
-         client.AddHandler("application/json", new JsonNetDeseralizer(JsonSettings));
-         return client;
-      }
-
-      protected virtual IAuthenticator GetAuthenticator()
-      {
-         return new CoinbaseApiAuthenticator(apiKey, apiSecret, useTimeApi, JsonSettings);
-      }
-
-      protected virtual IRestRequest CreateRequest(string action, Method method = Method.POST)
-      {
-         var post = new RestRequest(action, method)
-            {
-               RequestFormat = DataFormat.Json,
-               JsonSerializer = new JsonNetSerializer(JsonSettings),
-            };
-
-         return post;
-      }
-
-      /// <summary>
-      /// Sends a Raw Json object model to the endpoint using an HTTP method.
-      /// Recommended use is to use a JObject for the body or a serializable typesafe class.
-      /// </summary>
-      /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
-      /// <param name="body">The JSON request body</param>
-      /// <param name="httpMethod">The HTTP method to use. Default: POST.</param>
-      public virtual CoinbaseResponse SendRequest(string endpoint, object body, Method httpMethod = Method.POST)
-      {
-         var client = CreateClient();
-
-         var req = CreateRequest(endpoint, httpMethod)
-            .AddJsonBody(body);
-
-         var resp = client.Execute<CoinbaseResponse>(req);
-
-         return resp.Data;
-      }
-
-      /// <summary>
-      /// Sends a Raw Json object model to the endpoint using an HTTP method.
-      /// Recommended use is to use a JObject for the body or a serializable typesafe class.
-      /// </summary>
-      /// <typeparam name="TResponse">Type T of CoinbaseResponse.Data</typeparam>
-      /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
-      /// <param name="body">The JSON request body</param>
-      /// <param name="httpMethod">The HTTP method to use. Default: POST.</param>
-      public virtual CoinbaseResponse<TResponse> SendRequest<TResponse>(string endpoint, object body, Method httpMethod = Method.POST)
-      {
-         var client = CreateClient();
-
-         var req = CreateRequest(endpoint, httpMethod)
-            .AddJsonBody(body);
-
-         var resp = client.Execute<CoinbaseResponse<TResponse>>(req);
-
-         return resp.Data;
-      }
-
-
-      /// <summary>
-      /// Sends a get request to the endpoint using GET HTTP method.
-      /// </summary>
-      /// <typeparam name="TResponse">Type T of CoinbaseResponse.Data</typeparam>
-      /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
-      /// <param name="queryParams">Query URL parameters to include in the GET request.</param>
-      public virtual CoinbaseResponse<TResponse> SendGetRequest<TResponse>(string endpoint, params KeyValuePair<string, string>[] queryParams)
-      {
-         var client = CreateClient();
-
-         var req = CreateRequest(endpoint, Method.GET);
-         if( queryParams != null )
-         {
-            foreach( var kvp in queryParams )
-            {
-               req.AddQueryParameter(kvp.Key, kvp.Value);
+                this.apiCheckoutUrl = CoinbaseConstants.TestCheckoutUrl;
             }
-         }
+            if (string.IsNullOrWhiteSpace(options.ApiKey))
+            {
+                throw new ArgumentException("The API key must be specified.", nameof(options.ApiKey));
+            }
+            if (string.IsNullOrWhiteSpace(options.ApiSecret))
+            {
+                throw new ArgumentException("The API secret must be specified.", nameof(options.ApiSecret));
+            }
 
-         var resp = client.Execute<CoinbaseResponse<TResponse>>(req);
+            this.apiKey = options.ApiKey;
+            this.apiSecret = options.ApiSecret;
+            this.apiCheckoutUrl = !string.IsNullOrWhiteSpace(options.CheckoutUrl) ? 
+                options.CheckoutUrl : CoinbaseConstants.LiveCheckoutUrl;
+            this.useTimeApi = options.UseTimeApi;
+        }
 
-         return resp.Data;
-      }
+        protected override IAuthenticator GetAuthenticator()
+        {
+            return new CoinbaseApiAuthenticator(apiKey, apiSecret, useTimeApi, JsonSettings);
+        }
 
-      /// <summary>
-      /// Creates a new merchant order checkout product.
-      /// All checkouts and subsequent orders created using this endpoint are created for merchant’s primary account.
-      /// Using this endpoint to create checkouts and orders is useful when you want to build a merchant checkout experience with Coinbase’s merchant tools.
-      /// </summary>
-      public virtual CoinbaseResponse CreateCheckout(CheckoutRequest checkout)
-      {
-         return SendRequest("checkouts", checkout);
-      }
+        /// <summary>
+        /// Creates a new merchant order checkout product.
+        /// All checkouts and subsequent orders created using this endpoint are created for merchant’s primary account.
+        /// Using this endpoint to create checkouts and orders is useful when you want to build a merchant checkout experience with Coinbase’s merchant tools.
+        /// </summary>
+        public virtual CoinbaseResponse CreateCheckout(CheckoutRequest checkout)
+        {
+            return SendRequest("checkouts", checkout);
+        }
 
-      /// <summary>
-      /// Get the API server time.
-      /// </summary>
-      public virtual Time GetTime()
-      {
-         var resp = SendRequest<Time>("time", null, Method.GET);
-         return resp.Data;
-      }
+        /// <summary>
+        /// Get the API server time.
+        /// </summary>
+        public virtual Time GetTime()
+        {
+            var resp = SendRequest<Time>("time", null, Method.GET);
+            return resp.Data;
+        }
 
-      /// <summary>
-      /// Get the final checkout redirect URL from a CoinbaseResponse. The response
-      /// from CreateCheckout() call should be used.
-      /// </summary>
-      /// <param name="checkoutResponse">The response from calling CreateCheckout()</param>
-      /// <returns>The redirect URL for the customer checking out</returns>
-      public virtual string GetCheckoutUrl(CoinbaseResponse checkoutResponse)
-      {
-         var id = checkoutResponse.Data["id"]?.ToString();
-         if( string.IsNullOrWhiteSpace(id) )
-            throw new ArgumentException("The checkout response must have an ID field. None was found.", nameof(checkoutResponse));
+        /// <summary>
+        /// Get the final checkout redirect URL from a CoinbaseResponse. The response
+        /// from CreateCheckout() call should be used.
+        /// </summary>
+        /// <param name="checkoutResponse">The response from calling CreateCheckout()</param>
+        /// <returns>The redirect URL for the customer checking out</returns>
+        public virtual string GetCheckoutUrl(CoinbaseResponse checkoutResponse)
+        {
+            var id = checkoutResponse.Data["id"]?.ToString();
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("The checkout response must have an ID field. None was found.", nameof(checkoutResponse));
 
-         return apiCheckoutUrl.Replace("{code}", id);
-      }
+            return apiCheckoutUrl.Replace("{code}", id);
+        }
 
-      /// <summary>
-      /// Gets a notification object from JSON.
-      /// </summary>
-      /// <param name="json">Received from Coinbase in the HTTP callback</param>
-      /// <returns></returns>
-      public virtual Notification GetNotification(string json)
-      {
-         return JsonConvert.DeserializeObject<Notification>(json, JsonSettings);
-      }
-   }
+        /// <summary>
+        /// Gets a notification object from JSON.
+        /// </summary>
+        /// <param name="json">Received from Coinbase in the HTTP callback</param>
+        /// <returns></returns>
+        public virtual Notification GetNotification(string json)
+        {
+            return JsonConvert.DeserializeObject<Notification>(json, JsonSettings);
+        }
+    }
 }

--- a/Source/Coinbase/CoinbaseApi.cs
+++ b/Source/Coinbase/CoinbaseApi.cs
@@ -32,6 +32,47 @@ namespace Coinbase
         /// <summary>
         /// The main class for making Coinbase API calls.
         /// </summary>
+        /// <param name="apiKey">Your API key</param>
+        /// <param name="apiSecret">Your API secret</param>
+        /// <param name="useTimeApi">Use Coinbase's Time API in signing requests. Results in 2 requests per call 
+        /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
+        /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
+        /// https://developers.coinbase.com/api/v2#api-key </param>
+        [Obsolete("Use CoinbaseApiOptions Constructor")]
+        public CoinbaseApi(string apiKey = "", string apiSecret = "", bool useSandbox = false, WebProxy proxy = null, bool useTimeApi = true) :
+           this(apiKey, apiSecret, null, null, useTimeApi, proxy)
+        {
+            if(useSandbox)
+            {
+                this.apiCheckoutUrl = CoinbaseConstants.TestCheckoutUrl;
+            }
+        }
+
+        /// <summary>
+        /// The main class for making Coinbase API calls.
+        /// </summary>
+        /// <param name="apiKey">Your API Key</param>
+        /// <param name="apiSecret">Your API Secret </param>
+        /// <param name="customApiEndpoint">A custom URL endpoint. Typically, you'd use this if you want to use the sandbox URL.</param>
+        /// <param name="useTimeApi">Use Coinbase's Time API in signing requests. Results in 2 requests per call 
+        /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
+        /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
+        /// https://developers.coinbase.com/api/v2#api-key </param>
+        [Obsolete("Use CoinbaseApiOptions Constructor")]
+        public CoinbaseApi(
+           string apiKey,
+           string apiSecret,
+           string apiUrl = CoinbaseConstants.LiveApiUrl,
+           string checkoutUrl = CoinbaseConstants.LiveCheckoutUrl,
+           bool useTimeApi = true,
+           WebProxy proxy = null) : base(new CoinbaseApiOptions(apiKey, apiSecret, checkoutUrl, apiUrl, proxy, false, useTimeApi ))
+        {
+            this.apiCheckoutUrl = !string.IsNullOrWhiteSpace(checkoutUrl) ? checkoutUrl : CoinbaseConstants.LiveCheckoutUrl;
+        }
+        
+        /// <summary>
+        /// The main class for making Coinbase API calls.
+        /// </summary>
         public CoinbaseApi(CoinbaseApiOptions options) : base(options)
         {
             //Issue #11 -- Check .NET's SecurityProtocol compatibility with Coinbase API Server

--- a/Source/Coinbase/CoinbaseApiBase.cs
+++ b/Source/Coinbase/CoinbaseApiBase.cs
@@ -1,0 +1,204 @@
+﻿using Coinbase.Exceptions;
+using Coinbase.ObjectModel;
+using Coinbase.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using RestSharp;
+using RestSharp.Authenticators;
+using RestSharp.Deserializers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Coinbase
+{
+    public abstract class CoinbaseApiBase
+    {
+        
+        public JsonSerializerSettings JsonSettings = new JsonSerializerSettings
+        {
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        };
+
+        internal readonly WebProxy proxy;
+        internal readonly string apiUrl;
+
+        public CoinbaseApiBase(CoinbaseOptions options)
+        {
+            this.apiUrl = options.ApiUrl;
+            if(string.IsNullOrEmpty(options.ApiUrl))
+            {
+                this.apiUrl = options.UseSandbox ? CoinbaseConstants.TestApiUrl : CoinbaseConstants.LiveApiUrl;
+            }
+        }
+
+        protected virtual RestClient CreateClient()
+        {
+            var client = new RestClient(apiUrl)
+            {
+                Proxy = this.proxy,
+                Authenticator = GetAuthenticator()
+            };
+
+            client.AddHandler("application/json", new JsonNetDeseralizer(JsonSettings));
+            return client;
+        }
+
+        protected abstract IAuthenticator GetAuthenticator();
+
+        protected virtual IRestRequest CreateRequest(string action, Method method = Method.POST)
+        {
+            var post = new RestRequest(action, method)
+            {
+                RequestFormat = DataFormat.Json,
+                JsonSerializer = new JsonNetSerializer(JsonSettings),
+            };
+
+            return post;
+        }
+
+        /// <summary>
+        /// Sends a Raw Json object model to the endpoint using an HTTP method.
+        /// Recommended use is to use a JObject for the body or a serializable typesafe class.
+        /// </summary>
+        /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
+        /// <param name="body">The JSON request body</param>
+        /// <param name="httpMethod">The HTTP method to use. Default: POST.</param>
+        public virtual CoinbaseResponse SendRequest(RequestOptions requestOptions)
+        {
+            return this.SendRequest<CoinbaseResponse, JToken>(requestOptions);
+        }
+
+        /// <summary>
+        /// Sends a Raw Json object model to the endpoint using an HTTP method.
+        /// Recommended use is to use a JObject for the body or a serializable typesafe class.
+        /// </summary>
+        /// <typeparam name="TResponse">Type T of CoinbaseResponse.Data</typeparam>
+        public virtual CoinbaseResponse<TResponse> SendRequest<TResponse>(RequestOptions requestOptions)
+        {
+            return this.SendRequest<CoinbaseResponse<TResponse>, TResponse>(requestOptions);
+        }
+
+        /// <summary>
+        /// Sends a Raw Json object model to the endpoint using an HTTP method.
+        /// Recommended use is to use a JObject for the body or a serializable typesafe class.
+        /// </summary>
+        /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
+        /// <param name="body">The JSON request body</param>
+        /// <param name="httpMethod">The HTTP method to use. Default: POST.</param>
+        public virtual CoinbaseResponse SendRequest(string endpoint, object body, Method httpMethod = Method.POST)
+        {
+            var client = CreateClient();
+
+            var req = CreateRequest(endpoint, httpMethod)
+                .AddJsonBody(body);
+
+            return this.GetResponse<CoinbaseResponse, JToken>(client, req);
+        }
+
+        /// <summary>
+        /// Sends a Raw Json object model to the endpoint using an HTTP method.
+        /// Recommended use is to use a JObject for the body or a serializable typesafe class.
+        /// </summary>
+        /// <typeparam name="TResponse">Type T of CoinbaseResponse.Data</typeparam>
+        /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
+        /// <param name="body">The JSON request body</param>
+        /// <param name="httpMethod">The HTTP method to use. Default: POST.</param>
+        public virtual CoinbaseResponse<TResponse> SendRequest<TResponse>(string endpoint, object body, Method httpMethod = Method.POST)
+        {
+            var client = CreateClient();
+
+            var req = CreateRequest(endpoint, httpMethod)
+               .AddJsonBody(body);
+
+            return this.GetResponse<TResponse>(client, req);
+        }
+
+
+        /// <summary>
+        /// Sends a get request to the endpoint using GET HTTP method.
+        /// </summary>
+        /// <typeparam name="TResponse">Type T of CoinbaseResponse.Data</typeparam>
+        /// <param name="endpoint">The API endpoint. Ex: /checkout, /orders, /time</param>
+        /// <param name="queryParams">Query URL parameters to include in the GET request.</param>
+        public virtual CoinbaseResponse<TResponse> SendGetRequest<TResponse>(string endpoint, params KeyValuePair<string, string>[] queryParams)
+        {
+            var client = CreateClient();
+
+            var req = CreateRequest(endpoint, Method.GET);
+            if (queryParams != null)
+            {
+                foreach (var kvp in queryParams)
+                {
+                    req.AddQueryParameter(kvp.Key, kvp.Value);
+                }
+            }
+
+            return this.GetResponse<TResponse>(client, req);
+        }
+
+        /// <summary>
+        /// Sends a Raw Json object model to the endpoint using an HTTP method.
+        /// Recommended use is to use a JObject for the body or a serializable typesafe class.
+        /// </summary>
+        /// <typeparam name="TResponse">Type T of CoinbaseResponse Where T is CoinbaseResponse<TData></typeparam>
+        /// <typeparam name="TData">Type T of Response Data</typeparam>
+        public virtual TResponse SendRequest<TResponse, TData>(RequestOptions requestOptions)
+            where TResponse : CoinbaseResponse<TData>, new()
+        {
+            var client = CreateClient();
+
+            var req = CreateRequest(requestOptions.Endpoint, requestOptions.HttpMethod);
+            requestOptions.Parameters.ForEach(param => req.AddOrUpdateParameter(param));
+
+            return this.GetResponse<TResponse, TData>(client, req);
+        }
+
+        protected CoinbaseResponse<TData> GetResponse<TData>(RestClient client, IRestRequest req)
+        {
+            var resp = client.Execute<CoinbaseResponse<TData>>(req);
+            this.HandleKnownExceptions(resp);
+            return resp.Data;
+        }
+
+        protected TResponse GetResponse<TResponse, TData>(RestClient client, IRestRequest req) 
+            where TResponse : CoinbaseResponse<TData>, new()
+        {
+            var resp = client.Execute<TResponse>(req);
+            this.HandleKnownExceptions(resp);
+            return resp.Data;
+        }
+
+        protected void HandleKnownExceptions(IRestResponse response)
+        {
+            IDeserializer deserializer = null;
+            ErrorResponse error = null;
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.Unauthorized:
+                    deserializer = new JsonNetDeseralizer(JsonSettings);
+                    error = deserializer.Deserialize<ErrorResponse>(response);
+                    if(error.Id == "expired_token")
+                        throw new TokenExpiredException(response.StatusCode, error);
+                    break;
+                case HttpStatusCode.Forbidden:
+                    deserializer = new JsonNetDeseralizer(JsonSettings);
+                    error = deserializer.Deserialize<ErrorResponse>(response);
+
+                    if(error.Id == "invalid_scope")
+                        throw new InvalidScopeException(response.StatusCode, error);
+                    break;
+                case HttpStatusCode.PaymentRequired:
+                    deserializer = new JsonNetDeseralizer(JsonSettings);
+                    error = deserializer.Deserialize<ErrorResponse>(response);
+                    throw new Transaction2FaRequiredException(response.StatusCode, error);
+                    break;
+            }
+        }
+    }
+}

--- a/Source/Coinbase/CoinbaseApiOptions.cs
+++ b/Source/Coinbase/CoinbaseApiOptions.cs
@@ -9,10 +9,17 @@ namespace Coinbase
 {
     public class CoinbaseOptions
     {
+        public CoinbaseOptions(string apiUrl = CoinbaseConstants.LiveApiUrl, WebProxy proxy = null, 
+            bool useSandbox = false)
+        {
+            this.ApiUrl = apiUrl;
+            this.UseSandbox = useSandbox;
+            this.Proxy = proxy;
+        }
         /// <summary>
         /// Coinbase Api Endpint
         /// </summary>
-        public string ApiUrl { get; set; } = CoinbaseConstants.LiveApiUrl;
+        public string ApiUrl { get; set; }
 
         /// <summary>
         /// Flag to use Test Endpoints
@@ -23,16 +30,18 @@ namespace Coinbase
         /// Web Proxy for to use in the Coinbase Api
         /// </summary>
         public WebProxy Proxy { get; set; }
-
-        /// Use Coinbase's Time API in signing requests. Results in 2 requests per call 
-        /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
-        /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
-        /// https://developers.coinbase.com/api/v2#api-key
-        public bool UseTimeApi { get; set; } = true;
     }
 
     public class CoinbaseApiOptions : CoinbaseOptions
     {
+
+        public CoinbaseApiOptions(string apiKey, string apiSecret,
+            string checkoutUrl = CoinbaseConstants.LiveCheckoutUrl,
+            string apiUrl = CoinbaseConstants.LiveApiUrl, WebProxy proxy = null,
+            bool useSandbox = false, bool useTimeApi = true) : base(apiUrl, proxy, useSandbox)
+        {
+            this.UseTimeApi = useTimeApi;
+        }
         /// <summary>
         /// Coinbase Checkout Endpoint
         /// </summary>
@@ -47,6 +56,12 @@ namespace Coinbase
         /// Api Secret
         /// </summary>
         public string ApiSecret { get; set; }
+
+        /// Use Coinbase's Time API in signing requests. Results in 2 requests per call 
+        /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
+        /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
+        /// https://developers.coinbase.com/api/v2#api-key
+        public bool UseTimeApi { get; set; }
     }
 
     public class CoinbaseOAuthOptions : CoinbaseOptions

--- a/Source/Coinbase/CoinbaseApiOptions.cs
+++ b/Source/Coinbase/CoinbaseApiOptions.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Coinbase
+{
+    public class CoinbaseOptions
+    {
+        /// <summary>
+        /// Coinbase Api Endpint
+        /// </summary>
+        public string ApiUrl { get; set; } = CoinbaseConstants.LiveApiUrl;
+
+        /// <summary>
+        /// Flag to use Test Endpoints
+        /// </summary>
+        public bool UseSandbox { get; set; }
+
+        /// <summary>
+        /// Web Proxy for to use in the Coinbase Api
+        /// </summary>
+        public WebProxy Proxy { get; set; }
+
+        /// Use Coinbase's Time API in signing requests. Results in 2 requests per call 
+        /// (one to get time, one to send signed request). Uses coinbase server to prevent clock skew. If useTimeApi=false
+        /// you must make sure your server time does not drift apart from Coinbase's server time. Read more here: 
+        /// https://developers.coinbase.com/api/v2#api-key
+        public bool UseTimeApi { get; set; } = true;
+    }
+
+    public class CoinbaseApiOptions : CoinbaseOptions
+    {
+        /// <summary>
+        /// Coinbase Checkout Endpoint
+        /// </summary>
+        public string CheckoutUrl { get; set; } = CoinbaseConstants.LiveCheckoutUrl;
+
+        /// <summary>
+        /// Api Key
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Api Secret
+        /// </summary>
+        public string ApiSecret { get; set; }
+    }
+
+    public class CoinbaseOAuthOptions : CoinbaseOptions
+    {
+
+        /// <summary>
+        /// OAuth Access Token
+        /// </summary>
+        public string AccessToken { get; set; }
+
+        /// <summary>
+        /// OAuth Refresh Token
+        /// </summary>
+        public string RefreshToken { get; set; }
+    }
+
+}

--- a/Source/Coinbase/CoinbaseOAuth.cs
+++ b/Source/Coinbase/CoinbaseOAuth.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RestSharp.Authenticators;
+
+namespace Coinbase
+{
+    public class CoinbaseOAuth : CoinbaseApiBase
+    {
+        protected CoinbaseOAuthOptions options;
+        public CoinbaseOAuth(CoinbaseOAuthOptions options) : base(options)
+        {
+            this.options = options;
+        }
+
+        protected override IAuthenticator GetAuthenticator()
+        {
+            return new CoinbaseOAuthAuthenticator(options);
+        }
+    }
+}

--- a/Source/Coinbase/CoinbaseOAuthAuthenticator.cs
+++ b/Source/Coinbase/CoinbaseOAuthAuthenticator.cs
@@ -1,0 +1,27 @@
+﻿using RestSharp;
+using RestSharp.Authenticators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Coinbase
+{
+    public class CoinbaseOAuthAuthenticator : IAuthenticator
+    {
+        //TODO: Support Refresh Tokens
+        protected CoinbaseOAuthOptions options;
+
+        public CoinbaseOAuthAuthenticator(CoinbaseOAuthOptions options)
+        {
+            this.options = options;
+        }
+
+        public void Authenticate(IRestClient client, IRestRequest request)
+        {
+            request.AddHeader("Authorization", $"Bearer {options.AccessToken}")
+                   .AddHeader(CoinbaseConstants.CBVersionHeader, CoinbaseConstants.ApiVersionDate);
+        }
+    }
+}

--- a/Source/Coinbase/Exceptions/Exceptions.cs
+++ b/Source/Coinbase/Exceptions/Exceptions.cs
@@ -1,0 +1,51 @@
+﻿using Coinbase.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Coinbase.Exceptions
+{
+    public class CoinbaseApiException : Exception
+    {
+        public HttpStatusCode StatusCode { get; set; }
+        public ErrorResponse ErrorResponse { get; set; }
+        public CoinbaseApiException(HttpStatusCode statusCode,  ErrorResponse errorResponse)
+        {
+            this.StatusCode = statusCode;
+            this.ErrorResponse = errorResponse;
+        }
+    }
+
+    public class TokenExpiredException : CoinbaseApiException
+    {
+        public TokenExpiredException(HttpStatusCode statusCode, ErrorResponse errorResponse) 
+            : base(statusCode, errorResponse)
+        {
+        }
+
+        public override string Message => "Token Has Expired";
+    }
+
+    public class InvalidScopeException : CoinbaseApiException
+    {
+        public InvalidScopeException(HttpStatusCode statusCode, ErrorResponse errorResponse) 
+            : base(statusCode, errorResponse)
+        {
+        }
+
+        public override string Message => "Forbidden, Check your scopes to make sure you have Access Priviledges";
+    }
+
+    public class Transaction2FaRequiredException : CoinbaseApiException
+    {
+        public Transaction2FaRequiredException(HttpStatusCode statusCode, ErrorResponse errorResponse)
+            : base(statusCode, errorResponse)
+        {
+        }
+
+        public override string Message => "Two factor authentication is required, replay the request with the 2FA Token";
+    }
+}

--- a/Source/Coinbase/ObjectModel/ErrorResponse.cs
+++ b/Source/Coinbase/ObjectModel/ErrorResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Coinbase.ObjectModel
+{
+    public class ErrorResponse
+    {
+        public string Id { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/Source/Coinbase/ObjectModel/ErrorResponse.cs
+++ b/Source/Coinbase/ObjectModel/ErrorResponse.cs
@@ -8,6 +8,11 @@ namespace Coinbase.ObjectModel
 {
     public class ErrorResponse
     {
+        public List<Error> Errors { get; set; }
+    }
+
+    public class Error
+    {
         public string Id { get; set; }
         public string Message { get; set; }
     }

--- a/Source/Coinbase/ObjectModel/RequestOptions.cs
+++ b/Source/Coinbase/ObjectModel/RequestOptions.cs
@@ -40,7 +40,7 @@ namespace Coinbase.ObjectModel
         /// </summary>
         /// <param name="name">The name/key of the parameter</param>
         /// <param name="value"> the parameter value</param>
-        public void AddParameter(string name, string value)
+        public void AddParameter(string name, object value)
         {
             this.AddParameter(name, value, ParameterType.GetOrPost);
         }
@@ -50,7 +50,7 @@ namespace Coinbase.ObjectModel
         /// </summary>
         /// <param name="name">The name/key of the parameter</param>
         /// <param name="value"> the parameter value</param>
-        public void AddHeader(string name, string value)
+        public void AddHeader(string name, object value)
         {
             this.AddParameter(name, value, ParameterType.HttpHeader);
         }
@@ -61,7 +61,7 @@ namespace Coinbase.ObjectModel
         /// <param name="name">The name/key of the parameter</param>
         /// <param name="value"> the parameter value</param>
         /// <param name="type">Parameter Type: e.g Querystring, Body, Header</param>
-        public void AddParameter(string name, string value, ParameterType type)
+        public void AddParameter(string name, object value, ParameterType type)
         {
             var parameter = new Parameter();
             parameter.Type = type;

--- a/Source/Coinbase/ObjectModel/RequestOptions.cs
+++ b/Source/Coinbase/ObjectModel/RequestOptions.cs
@@ -1,0 +1,73 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Coinbase.ObjectModel
+{
+    public class RequestOptions
+    {
+        /// <summary>
+        /// The API endpoint. Ex: /checkout, /orders, /time
+        /// </summary>
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// The HTTP method to use. Default: POST
+        /// </summary>
+        public Method HttpMethod { get; set; } = Method.POST;
+        //string endpoint, object body, Method httpMethod = Method.POST
+
+        /// <summary>
+        /// List Of Request Parameters
+        /// </summary>
+        public List<Parameter> Parameters { get; set; } = new List<Parameter>();
+
+        /// <summary>
+        /// Initializes the Request Options
+        /// </summary>
+        public RequestOptions(string endpoint, Method httpMethod = Method.POST)
+        {
+
+            this.Endpoint = endpoint;
+            this.HttpMethod = httpMethod;
+        }
+
+        /// <summary>
+        /// Adds a parameter based on the type of request your making e.g (GET: Querystring, POST: body)
+        /// </summary>
+        /// <param name="name">The name/key of the parameter</param>
+        /// <param name="value"> the parameter value</param>
+        public void AddParameter(string name, string value)
+        {
+            this.AddParameter(name, value, ParameterType.GetOrPost);
+        }
+
+        /// <summary>
+        /// Adds a Header to your request
+        /// </summary>
+        /// <param name="name">The name/key of the parameter</param>
+        /// <param name="value"> the parameter value</param>
+        public void AddHeader(string name, string value)
+        {
+            this.AddParameter(name, value, ParameterType.HttpHeader);
+        }
+
+        /// <summary>
+        /// Adds a parameter to the request
+        /// </summary>
+        /// <param name="name">The name/key of the parameter</param>
+        /// <param name="value"> the parameter value</param>
+        /// <param name="type">Parameter Type: e.g Querystring, Body, Header</param>
+        public void AddParameter(string name, string value, ParameterType type)
+        {
+            var parameter = new Parameter();
+            parameter.Type = type;
+            parameter.Name = name;
+            parameter.Value = value;
+            this.Parameters.Add(parameter);
+        }
+    }
+}


### PR DESCRIPTION
I've added support for OAuth.
Adding Simple Error Handling.
Simplified Constructors
Everything should be backwards comaptible

This method seemed wierd to me seemed like this should be post only why would someone add a json body to a GET Request?:

    public virtual CoinbaseResponse SendRequest(string endpoint, object body, Method httpMethod = Method.POST)
    {
        var client = CreateClient();

        var req = CreateRequest(endpoint, httpMethod)
                .AddJsonBody(body);
        //...