### PR TITLE
Updating Coinbase Api to support multiple DI registration

### DIFF
--- a/Source/Coinbase.Tests/CoinbaseApiKeyTests.cs
+++ b/Source/Coinbase.Tests/CoinbaseApiKeyTests.cs
@@ -6,7 +6,7 @@ namespace Coinbase.Tests
    public class CoinbaseApiKeyTests : ServerTest
    {
       public string apiKey = "DBBD0428-B818-4F53-A5F4-F553DC4C374C";
-      private CoinbaseApi client;
+      private CoinbaseApiBase client;
 
       [SetUp]
       public void BeforeEachTest()
@@ -24,9 +24,9 @@ namespace Coinbase.Tests
       private void EnsureEveryRequestHasCorrectHeaders()
       {
          server.ShouldHaveMadeACall()
-            .WithHeader(HeaderNames.Version, CoinbaseApi.ApiVersionDate)
+            .WithHeader(HeaderNames.Version, CoinbaseApiBase.ApiVersionDate)
             .WithHeader(HeaderNames.AccessKey, apiKey)
-            .WithHeader("User-Agent", CoinbaseApi.UserAgent);
+            .WithHeader("User-Agent", CoinbaseApiBase.UserAgent);
       }
 
 

--- a/Source/Coinbase.Tests/Integration/DataTests.cs
+++ b/Source/Coinbase.Tests/Integration/DataTests.cs
@@ -11,12 +11,12 @@ namespace Coinbase.Tests.Integration
 {
    public class DataTests 
    {
-      private CoinbaseApi client;
+      private CoinbaseApiBase client;
 
       [SetUp]
       public void BeforeEachTest()
       {
-         client = new CoinbaseApi();
+         client = new PublicCoinbaseApi();
       }
 
       [Test]

--- a/Source/Coinbase.Tests/Integration/IntegrationTests.cs
+++ b/Source/Coinbase.Tests/Integration/IntegrationTests.cs
@@ -11,7 +11,7 @@ namespace Coinbase.Tests.Integration
    [Explicit]
    public class IntegrationTests
    {
-      protected CoinbaseApi client;
+      protected CoinbaseApiBase client;
 
       public IntegrationTests()
       {

--- a/Source/Coinbase.Tests/ServerTest.cs
+++ b/Source/Coinbase.Tests/ServerTest.cs
@@ -44,14 +44,14 @@ namespace Coinbase.Tests
 
    public class OAuthServerTest : ServerTest
    {
-      protected CoinbaseApi client;
+      protected CoinbaseApiBase client;
 
       public string oauthKey = "369ECD3F-2D00-4D7A-ACDB-92C2DC35A878";
 
       [SetUp]
       public void BeforeEachTest()
       {
-         client = new CoinbaseApi(new OAuthConfig{OAuthToken = oauthKey});
+         client = new CoinbaseOAuthApi(new OAuthConfig{OAuthToken = oauthKey});
       }
 
       [TearDown]
@@ -63,8 +63,8 @@ namespace Coinbase.Tests
       private void EnsureEveryRequestHasCorrectHeaders()
       {
          server.ShouldHaveMadeACall()
-            .WithHeader(HeaderNames.Version, CoinbaseApi.ApiVersionDate)
-            .WithHeader("User-Agent", CoinbaseApi.UserAgent)
+            .WithHeader(HeaderNames.Version, CoinbaseApiBase.ApiVersionDate)
+            .WithHeader("User-Agent", CoinbaseApiBase.UserAgent)
             .WithHeader("Authorization", $"Bearer {oauthKey}");
       }
    }

--- a/Source/Coinbase/CoinbaseApi.Accounts.cs
+++ b/Source/Coinbase/CoinbaseApi.Accounts.cs
@@ -40,7 +40,7 @@ namespace Coinbase
    }
 
 
-   public partial class CoinbaseApi : IAccountsEndpoint
+   public partial class CoinbaseApiBase : IAccountsEndpoint
    {
       public IAccountsEndpoint Accounts => this;
 

--- a/Source/Coinbase/CoinbaseApi.Addresses.cs
+++ b/Source/Coinbase/CoinbaseApi.Addresses.cs
@@ -31,7 +31,7 @@ namespace Coinbase
    }
 
 
-   public partial class CoinbaseApi : IAddressesEndpoint
+   public partial class CoinbaseApiBase : IAddressesEndpoint
    {
       public IAddressesEndpoint Addresses => this;
 

--- a/Source/Coinbase/CoinbaseApi.Buys.cs
+++ b/Source/Coinbase/CoinbaseApi.Buys.cs
@@ -36,7 +36,7 @@ namespace Coinbase
       Task<Response<Buy>> CommitBuyAsync(string accountId, string buyId, CancellationToken cancellationToken = default);
    }
 
-   public partial class CoinbaseApi : IBuysEndpoint
+   public partial class CoinbaseApiBase : IBuysEndpoint
    {
       public IBuysEndpoint Buys => this;
 

--- a/Source/Coinbase/CoinbaseApi.Data.cs
+++ b/Source/Coinbase/CoinbaseApi.Data.cs
@@ -48,7 +48,7 @@ namespace Coinbase
       Task<Response<Time>> GetCurrentTimeAsync(CancellationToken cancellationToken = default);
    }
 
-   public partial class CoinbaseApi : IDataEndpoint
+   public partial class CoinbaseApiBase : IDataEndpoint
    {
       public IDataEndpoint Data => this;
 

--- a/Source/Coinbase/CoinbaseApi.Deposits.cs
+++ b/Source/Coinbase/CoinbaseApi.Deposits.cs
@@ -27,7 +27,7 @@ namespace Coinbase
       Task<Response<Deposit>> CommitDepositAsync(string accountId, string depositId, CancellationToken cancellationToken = default);
    }
 
-   public partial class CoinbaseApi : IDepositsEndpoint
+   public partial class CoinbaseApiBase : IDepositsEndpoint
    {
       public IDepositsEndpoint Deposits => this;
 

--- a/Source/Coinbase/CoinbaseApi.Notifications.cs
+++ b/Source/Coinbase/CoinbaseApi.Notifications.cs
@@ -19,7 +19,7 @@ namespace Coinbase
       Task<Response<Notification>> GetNotificationAsync(string notificationId, CancellationToken cancellationToken = default);
    }
 
-   public partial class CoinbaseApi : INotificationsEndpoint
+   public partial class CoinbaseApiBase : INotificationsEndpoint
    {
       public INotificationsEndpoint Notifications => this;
 

--- a/Source/Coinbase/CoinbaseApi.PaymentMethods.cs
+++ b/Source/Coinbase/CoinbaseApi.PaymentMethods.cs
@@ -19,7 +19,7 @@ namespace Coinbase
       Task<Response<PaymentMethod>> GetPaymentMethodAsync(string paymentMethodId, CancellationToken cancellationToken = default);
    }
 
-   public partial class CoinbaseApi : IPaymentMethodsEndpoint
+   public partial class CoinbaseApiBase : IPaymentMethodsEndpoint
    {
       public IPaymentMethodsEndpoint PaymentMethods => this;
 

--- a/Source/Coinbase/CoinbaseApi.Sells.cs
+++ b/Source/Coinbase/CoinbaseApi.Sells.cs
@@ -36,7 +36,7 @@ namespace Coinbase
       Task<Response<Sell>> CommitSellAsync(string accountId, string sellId, CancellationToken cancellationToken = default);
    }
 
-   public partial class CoinbaseApi : ISellsEndpoint
+   public partial class CoinbaseApiBase : ISellsEndpoint
    {
       public ISellsEndpoint Sells => this;
 

--- a/Source/Coinbase/CoinbaseApi.Transactions.cs
+++ b/Source/Coinbase/CoinbaseApi.Transactions.cs
@@ -56,7 +56,7 @@ namespace Coinbase
    }
 
 
-   public partial class CoinbaseApi : ITransactionsEndpoint
+   public partial class CoinbaseApiBase : ITransactionsEndpoint
    {
       public ITransactionsEndpoint Transactions => this;
 

--- a/Source/Coinbase/CoinbaseApi.Users.cs
+++ b/Source/Coinbase/CoinbaseApi.Users.cs
@@ -31,7 +31,7 @@ namespace Coinbase
    }
 
 
-   public partial class CoinbaseApi : IUsersEndpoint
+   public partial class CoinbaseApiBase : IUsersEndpoint
    {
       public IUsersEndpoint Users => this;
 
@@ -42,7 +42,7 @@ namespace Coinbase
       {
          if (string.IsNullOrWhiteSpace(userId)) throw new ArgumentNullException(nameof(userId));
 
-         return this.config.ApiUrl
+         return this._config.ApiUrl
             .AppendPathSegments("users",userId)
             .WithClient(this)
             .GetJsonAsync<Response<User>>(cancellationToken);
@@ -52,7 +52,7 @@ namespace Coinbase
       /// </summary>
       Task<Response<User>> IUsersEndpoint.GetCurrentUserAsync(CancellationToken cancellationToken)
       {
-         return this.config.ApiUrl
+         return this._config.ApiUrl
             .AppendPathSegment("user")
             .WithClient(this)
             .GetJsonAsync<Response<User>>(cancellationToken);
@@ -62,7 +62,7 @@ namespace Coinbase
       /// </summary>
       Task<Response<Auth>> IUsersEndpoint.GetAuthInfoAsync(CancellationToken cancellationToken)
       {
-         return this.config.ApiUrl
+         return this._config.ApiUrl
             .AppendPathSegments("user", "auth")
             .WithClient(this)
             .GetJsonAsync<Response<Auth>>(cancellationToken);
@@ -72,7 +72,7 @@ namespace Coinbase
       /// </summary>
       Task<Response<User>> IUsersEndpoint.UpdateUserAsync(UserUpdate update, CancellationToken cancellationToken)
       {
-         return this.config.ApiUrl
+         return this._config.ApiUrl
             .AppendPathSegment("user")
             .WithClient(this)
             .PutJsonAsync(update, cancellationToken)

--- a/Source/Coinbase/CoinbaseApi.Withdrawals.cs
+++ b/Source/Coinbase/CoinbaseApi.Withdrawals.cs
@@ -27,7 +27,7 @@ namespace Coinbase
    }
 
 
-   public partial class CoinbaseApi : IWithdrawalsEndpoint
+   public partial class CoinbaseApiBase : IWithdrawalsEndpoint
    {
       public IWithdrawalsEndpoint Withdrawals => this;
 

--- a/Source/Coinbase/Config.cs
+++ b/Source/Coinbase/Config.cs
@@ -8,7 +8,7 @@ namespace Coinbase
       {
       }
 
-      public string ApiUrl { get; set; } = CoinbaseApi.Endpoint;
+      public string ApiUrl { get; set; } = CoinbaseApiBase.Endpoint;
       public bool UseTimeApi { get; set; } = true;
 
       internal virtual void EnsureValid()

--- a/Source/Examples/Program.cs
+++ b/Source/Examples/Program.cs
@@ -12,7 +12,7 @@ namespace Examples
       static async Task Main(string[] args)
       {
          Console.WriteLine("Hello World!");
-         var client = new CoinbaseApi();
+         var client = new PublicCoinbaseApi();
 
          var create = new CreateTransaction
             {
@@ -21,6 +21,7 @@ namespace Examples
             };
          var response = await client
             .WithHeader(TwoFactorToken, "ffff")
+            .AllowAnyHttpStatus()
             .Transactions.SendMoneyAsync("accountId", create);
 
          if( response.HasError() )


### PR DESCRIPTION
Separating out the coinbase Api into 3 seperate classes

OAuth Class
Api Class
Public Class (Ideally this class needs some refactoring)

Reasons:
1.  This allows users to configure 2 separate instances with the DI.  So you can have request Authorized from the Logged in OAuth User, and then make requests on behalf of the api.
2.  This will allow additional expansion in each respective class e.g(the oauth api should support auto refreshing tokens, but there is no need to include this within the ApiKeyClass)

Small Complications:
The original constructors took in Null Parameters for the Config.   This is partially a bug though the only reason to take in a null config would be if you wanted to make requests that aren't required to be authorized.  Ideally the public coinbase api should be a subset of the base, because if the user wanted to access transactions and was not authorized it would always throw so there's no sense in actually providing authorized endpoint for the public api 

I've prevented such a case but you may want to review the way i'm doing so.  I basically set the base class to only provide an internal construct which must be called with a value.   the internal config should never be out of sync then since in the child class is set to read only.


