### PR TITLE
Adding support for auto refresh tokens.

### DIFF
--- a/Source/Coinbase.Tests/Coinbase.Tests.csproj
+++ b/Source/Coinbase.Tests/Coinbase.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="CoinbaseApiKeyTests.cs" />
     <Compile Include="Endpoints\AccountTests.cs" />
     <Compile Include="Endpoints\NotificationTests.cs" />
+    <Compile Include="Endpoints\OAuthHelperTests.cs" />
     <Compile Include="Integration\DataTests.cs" />
     <Compile Include="Endpoints\PaymentMethodTest.cs" />
     <Compile Include="Endpoints\WithdrawlTests.cs" />

--- a/Source/Coinbase.Tests/Endpoints/OAuthHelperTests.cs
+++ b/Source/Coinbase.Tests/Endpoints/OAuthHelperTests.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Flurl;
+using Flurl.Http;
+using Flurl.Http.Testing;
+using NUnit.Framework;
+using Z.ExtensionMethods;
+
+namespace Coinbase.Tests.Endpoints
+{
+   public class OAuthHelperTests
+   {
+      private HttpTest server;
+
+      [SetUp]
+      public void BeforeEachTest()
+      {
+         server = new HttpTest();
+      }
+
+      [TearDown]
+      public void AfterEachTest()
+      {
+         server.Dispose();
+      }
+
+
+      [Test]
+      public async Task can_create_authorization_url()
+      {
+         var opts = new AuthorizeOptions
+         {
+            ClientId = "YOUR_CLIENT_ID",
+            RedirectUri = "YOUR_REDIRECT_URL",
+            State = "SECURE_RANDOM",
+            Scope = "wallet:accounts:read"
+         };
+         var authUrl = OAuthHelper.GetAuthorizeUrl(opts);
+
+         var url =
+            "https://www.coinbase.com/oauth/authorize?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=YOUR_REDIRECT_URL&state=SECURE_RANDOM&scope=wallet%3Aaccounts%3Aread";
+
+
+         var response = await authUrl.GetAsync();
+
+         server.ShouldHaveExactCall(url);
+
+      }
+
+      [Test]
+      public async Task can_revoke_token()
+      {
+         server.RespondWith("");
+
+         var x  = await OAuthHelper.RevokeTokenAsync("fff", "vvv");
+
+         server.ShouldHaveExactCall("https://api.coinbase.com/oauth/revoke")
+            .WithVerb(HttpMethod.Post)
+            .WithRequestBody("token=fff&access_token=vvv");
+      }
+
+
+      [Test]
+      public async Task can_get_access_token()
+      {
+         var tokenResponse = @"{
+""access_token"":""aaa"",
+""token_type"":""bearer"",
+""expires_in"":7200,
+""refresh_token"":""bbb"",
+""scope"":""wallet:user:read wallet:accounts:read"",
+""created_at"":1542649114
+}";
+         server.RespondWith(tokenResponse);
+
+         var token = await OAuthHelper.GetAccessTokenAsync(
+            code:"4c666b5c0c0d9d3140f2e0776cbe245f3143011d82b7a2c2a590cc7e20b79ae8",
+            clientId:"1532c63424622b6e9c4654e7f97ed40194a1547e114ca1c682f44283f39dfa49",
+            clientSecret:"3a21f08c585df35c14c0c43b832640b29a3a3a18e5c54d5401f08c87c8be0b20",
+            redirectUri: "http://localhost:8080/callback");
+         
+         server.ShouldHaveExactCall("https://api.coinbase.com/oauth/token")
+            .WithVerb(HttpMethod.Post)
+            .WithRequestBody("grant_type=authorization_code" +
+                             "&code=4c666b5c0c0d9d3140f2e0776cbe245f3143011d82b7a2c2a590cc7e20b79ae8" +
+                             "&client_id=1532c63424622b6e9c4654e7f97ed40194a1547e114ca1c682f44283f39dfa49" +
+                             "&client_secret=3a21f08c585df35c14c0c43b832640b29a3a3a18e5c54d5401f08c87c8be0b20" +
+                             $"&redirect_uri={Url.Encode("http://localhost:8080/callback")}");
+
+         token.AccessToken.Should().Be("aaa");
+         token.TokenType.Should().Be("bearer");
+         token.ExpiresInSeconds.Should().Be(7200);
+         token.Expires.TotalHours.Should().Be(2);
+         token.CreatedAt.Date.Should().Be(DateTime.Parse("11/19/2018", CultureInfo.InvariantCulture));
+         token.RefreshToken.Should().Be("bbb");
+         token.Scope.Should().Be("wallet:user:read wallet:accounts:read");
+      }
+
+
+      [Test]
+      public async Task can_refresh_token()
+      {
+         var tokenResponse = @"{
+""access_token"":""aaa"",
+""token_type"":""bearer"",
+""expires_in"":7200,
+""refresh_token"":""bbb"",
+""scope"":""all"",
+""created_at"":1542649114
+}";
+
+         server.RespondWith(tokenResponse);
+
+         var token = await OAuthHelper.RefreshTokenAsync("refresh", "clientid", "clientsecret");
+
+         server.ShouldHaveExactCall("https://api.coinbase.com/oauth/token")
+            .WithVerb(HttpMethod.Post)
+            .WithRequestBody("grant_type=refresh_token" +
+                             "&refresh_token=refresh" +
+                             "&client_id=clientid" +
+                             "&client_secret=clientsecret");
+
+         token.AccessToken.Should().Be("aaa");
+         token.TokenType.Should().Be("bearer");
+         token.ExpiresInSeconds.Should().Be(7200);
+         token.Expires.TotalHours.Should().Be(2);
+         token.CreatedAt.Date.Should().Be(DateTime.Parse("11/19/2018", CultureInfo.InvariantCulture));
+         token.RefreshToken.Should().Be("bbb");
+         token.Scope.Should().Be("all");
+      }
+   }
+}

--- a/Source/Coinbase.Tests/ServerTest.cs
+++ b/Source/Coinbase.Tests/ServerTest.cs
@@ -51,7 +51,7 @@ namespace Coinbase.Tests
       [SetUp]
       public void BeforeEachTest()
       {
-         client = new CoinbaseApi(new OAuthConfig{OAuthToken = oauthKey});
+         client = new CoinbaseApi(new OAuthConfig{AccessToken = oauthKey});
       }
 
       [TearDown]

--- a/Source/Coinbase/Coinbase.csproj
+++ b/Source/Coinbase/Coinbase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET implementation for the Coinbase API for online payments. The Coinbase API is a way to seamlessly pay for goods or services online utilizing Coinbase and Bitcoins for low-cost payment processing.</Description>
     <PackageReleaseNotes>
@@ -18,19 +18,14 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/bchavez/Coinbase/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/bchavez/Coinbase</RepositoryUrl>
-    <!--Source Link Settings-->
+    <CodeAnalysisRuleSet>Coinbase.ruleset</CodeAnalysisRuleSet>
+     <!--Source Link Settings-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>false</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);STANDARD</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
-    <CodeAnalysisRuleSet>Coinbase.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
-    <CodeAnalysisRuleSet>Coinbase.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="2.4.0" />

--- a/Source/Coinbase/Coinbase.csproj
+++ b/Source/Coinbase/Coinbase.csproj
@@ -26,6 +26,12 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);STANDARD</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <CodeAnalysisRuleSet>Coinbase.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
+    <CodeAnalysisRuleSet>Coinbase.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/Source/Coinbase/Coinbase.ruleset
+++ b/Source/Coinbase/Coinbase.ruleset
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Default" Description="" ToolsVersion="10.0">
+  <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
+    <Rule Id="RCS1090" Action="Error" />
+  </Rules>
+</RuleSet>

--- a/Source/Coinbase/CoinbaseApi.OAuth.cs
+++ b/Source/Coinbase/CoinbaseApi.OAuth.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Coinbase.Models;
+using Flurl;
+using Flurl.Http;
+
+namespace Coinbase
+{
+   /// <summary>
+   /// https://developers.coinbase.com/docs/wallet/coinbase-connect/integrating
+   /// https://developers.coinbase.com/docs/wallet/coinbase-connect/reference
+   /// </summary>
+   public class AuthorizeOptions
+   {
+      /// <summary>
+      /// Required The client ID you received after registering your application.
+      /// </summary>
+      public string ClientId { get; set; }
+
+      /// <summary>
+      /// Optional The URL in your app where users will be sent after authorization (see below). This value needs to be URL encoded. If left out, your application’s first redirect URI will be used by default.
+      /// </summary>
+      public string RedirectUri { get; set; }
+
+      /// <summary>
+      /// Optional An unguessable random string. It is used to protect against cross-site request forgery attacks.
+      /// </summary>
+      public string State { get; set; }
+
+      /// <summary>
+      /// Optional Comma separated list of permissions (scopes) your application requests access to. Required scopes are listed under endpoints in the Full Scopes List
+      /// </summary>
+      public string Scope { get; set; }
+
+      /// <summary>
+      /// For logged out users, login view is shown by default. You can show the sign up page instead with value signup
+      /// </summary>
+      public string Layout { get; set; }
+      /// <summary>
+      /// Earn a referral bonus from new users who sign up via OAuth. Value needs to be set to developer’s referral ID (username). Read more.
+      /// </summary>
+      public string Referral { get; set; }
+
+      /// <summary>
+      /// Change the account access the application will receive. Available values:
+      /// * 'select' (default) Allow user to pick the wallet associated with the application
+      /// * 'all' Application will get access to all of user’s wallets
+      /// For backward compatibility all is used as default for applications created prior to this change
+      /// </summary>
+      public string Account { get; set; }
+
+      public IDictionary<string, object> Meta { get; set; } = new Dictionary<string, object>();
+
+      /// <summary>
+      /// Name for this session (not a name for your application.) This will appear in the user’s account settings underneath your application’s name. Use it to provide identifying information if your app is often authorized multiple times
+      /// </summary>
+      public string Name
+      {
+         set => this.Meta["name"] = value;
+      }
+
+      public decimal SendLimitAmount
+      {
+         set => this.Meta["send_limit_amount"] = value;
+      }
+
+      public string SendLimitCurrency
+      {
+         set => this.Meta["send_limit_currency"] = value;
+      }
+
+      public string SendLimitPeriod
+      {
+         set => this.Meta["send_limit_period"] = value;
+      }
+   }
+
+   public static class OAuthHelper
+   {
+      public const string OAuthEndpoint = "https://api.coinbase.com/oauth";
+
+      public const string AuthorizeEndpoint = "https://www.coinbase.com/oauth/authorize";
+
+      /// <summary>
+      /// When redirecting a user to Coinbase to authorize access to your application,
+      /// you’ll need to construct the authorization URL with the correct parameters
+      /// and scopes. Here’s a list of parameters you should always specify:
+      /// </summary>
+      public static string GetAuthorizeUrl(AuthorizeOptions opts)
+      {
+         var url = AuthorizeEndpoint
+            .SetQueryParam("response_type", "code")
+            .SetQueryParam("client_id", opts.ClientId)
+            .SetQueryParam("redirect_uri", opts.RedirectUri)
+            .SetQueryParam("state", opts.State)
+            .SetQueryParam("scope", opts.Scope)
+            .SetQueryParam("layout", opts.Layout)
+            .SetQueryParam("referral", opts.Referral)
+            .SetQueryParam("account", opts.Account);
+
+         foreach( var kv in opts.Meta )
+         {
+            url.SetQueryParam($"meta[{kv.Key}]", kv.Value);
+         }
+
+         return url;
+      }
+
+      /// <summary>
+      /// After you have received the temporary code, you can exchange it for valid
+      /// access and refresh tokens.
+      /// </summary>
+      /// <param name="code">Required Value from the GetAuthorizeUrl step.</param>
+      /// <param name="clientId">Required The client ID you received after registering your application.</param>
+      /// <param name="clientSecret">Required The client secret you received after registering your application.</param>
+      /// <param name="redirectUri">Required Your application’s redirect URI</param>
+      public static Task<OAuthResponse> GetAccessTokenAsync(string code, string clientId, string clientSecret, string redirectUri)
+      {
+         var form = new
+            {
+               grant_type = "authorization_code",
+               code,
+               client_id = clientId,
+               client_secret = clientSecret,
+               redirect_uri = redirectUri
+            };
+
+         return OAuthEndpoint
+            .AppendPathSegment("token")
+            .PostUrlEncodedAsync(form)
+            .ReceiveJson<OAuthResponse>();
+      }
+
+      /// <summary>
+      /// Coinbase uses an optional security feature of OAuth2 called refresh tokens.
+      /// When you first authenticate, your app will be given an access_token and a
+      /// refresh_token. The access token is used to authenticate all your requests,
+      /// but expires in two hours. Once an access token has expired, you will need
+      /// to use the refresh token to obtain a new access token and a new refresh token.
+      /// The refresh token never expires but it can only be exchanged once for a new
+      /// set of access and refresh tokens. If you try to make a call with an expired
+      /// access token, a 401 response will be returned.
+      /// </summary>
+      /// <param name="refreshToken"></param>
+      /// <param name="clientId"></param>
+      /// <param name="clientSecret"></param>
+      /// <returns></returns>
+      public static Task<OAuthResponse> RefreshTokenAsync(string refreshToken, string clientId, string clientSecret)
+      {
+         var form = new
+            {
+               grant_type = "refresh_token",
+               refresh_token = refreshToken,
+               client_id = clientId,
+               client_secret = clientSecret
+            };
+         return OAuthEndpoint
+            .AppendPathSegment("token")
+            .PostUrlEncodedAsync(form)
+            .ReceiveJson<OAuthResponse>();
+      }
+
+      /// <summary>
+      /// Active access tokens can be revoked at any time. This request needs to be made authenticated like any other regular API request (either containing access_token parameter or Authentication header with bearer token) and 200 OK is returned for both successful and unsuccessful request. This can be useful, for example, when implementing log-out feature.
+      /// </summary>
+      /// <remarks>
+      /// Access tokens can be revoked manually if you want to disconnect your application’s access to the user’s account. Revoking can also be used to implement a log-out feature. You’ll need to supply the current access token twice, once to revoke it, and another to authenticate the request (either containing access_token parameter or Authentication header with bearer token). 200 OK is returned for both successful and unsuccessful requests.
+      /// </remarks>
+      /// <param name="token">The access token to expire.</param>
+      /// <param name="accessToken">The token used to make the authenticated request. This can be the same as the token in the first parameter.</param>
+      public static Task<HttpResponseMessage> RevokeTokenAsync(string token, string accessToken)
+      {
+         var form = new
+            {
+               token,
+               access_token = accessToken
+            };
+         return OAuthEndpoint
+            .AppendPathSegment("revoke")
+            .PostUrlEncodedAsync(form);
+      }
+   }
+
+   public static class AutoRefreshTokenHelper
+   {
+      public const string ExpiredToken = "expired_token";
+
+      public static CoinbaseApi WithAutomaticOAuthTokenRefresh(this CoinbaseApi client, string clientId, string clientSecret, string refreshToken)
+      {
+         if (client.config is OAuthConfig config) { }
+         else throw new InvalidOperationException($"Client must be using an {nameof(OAuthConfig)}");
+
+         async Task TokenExpiredErrorHandler(HttpCall call)
+         {
+            var exception = call.Exception;
+            if (exception is FlurlHttpException ex)
+            {
+               var errorResponse = await ex.GetResponseJsonAsync<JsonResponse>().ConfigureAwait(false);
+               if (errorResponse.Errors.Any(x => x.Id == ExpiredToken))
+               {
+                  var refresh = await OAuthHelper.RefreshTokenAsync(refreshToken, clientId, clientSecret).ConfigureAwait(false);
+                  config.AccessToken = refresh.AccessToken;
+                  refreshToken = refresh.RefreshToken;
+
+                  call.Response = await call.FlurlRequest.SendAsync(call.Request.Method, call.Request.Content).ConfigureAwait(false);
+                  call.ExceptionHandled = true;
+               }
+            }
+         }
+
+         client.Configure(s => s.OnErrorAsync = TokenExpiredErrorHandler);
+         return client;
+      }
+   }
+}

--- a/Source/Coinbase/CoinbaseApi.cs
+++ b/Source/Coinbase/CoinbaseApi.cs
@@ -136,6 +136,7 @@ namespace Coinbase
             oauthConfig.RefreshToken = response.RefreshToken;
             oauthConfig.OAuthToken = response.AccessToken;
 
+            await oauthConfig.OnTokenRefresh(response).ConfigureAwait(false);
             return response;
       }     
 

--- a/Source/Coinbase/CoinbaseApi.cs
+++ b/Source/Coinbase/CoinbaseApi.cs
@@ -105,14 +105,16 @@ namespace Coinbase
       public async Task HandleErrorAsync(HttpCall call)
       {
             var exception = call.Exception;
-            if (exception is FlurlHttpException)
+            if (exception is FlurlHttpException ex)
             {
-                FlurlHttpException ex = (exception as FlurlHttpException);
-                var errorResponse = await ex.GetResponseJsonAsync<ErrorResponse>();
+               var errorResponse = await ex.GetResponseJsonAsync<ErrorResponse>()
+                  .ConfigureAwait(false);
                 if (errorResponse.Errors.Any(x => x.Id == EXPIRED_TOKEN))
                 {
-                    var tokenResponse = await this.RefreshOAuthToken();
-                    call.Response = await call.FlurlRequest.SendAsync(call.Request.Method, call.Request.Content);
+                    var tokenResponse = await this.RefreshOAuthToken()
+                       .ConfigureAwait(false);
+                    call.Response = await call.FlurlRequest.SendAsync(call.Request.Method, call.Request.Content)
+                       .ConfigureAwait(false);
                     call.ExceptionHandled = true;
                 }
             }
@@ -129,7 +131,7 @@ namespace Coinbase
 
             var response = await oauthConfig.TokenEndpoint.WithClient(this)
                 .PostJsonAsync(data, cancellationToken)
-                .ReceiveJson<RefreshResponse>();
+                .ReceiveJson<RefreshResponse>().ConfigureAwait(false);
 
             oauthConfig.RefreshToken = response.RefreshToken;
             oauthConfig.OAuthToken = response.AccessToken;

--- a/Source/Coinbase/CoinbaseApiAuthenticator.cs
+++ b/Source/Coinbase/CoinbaseApiAuthenticator.cs
@@ -9,7 +9,6 @@ namespace Coinbase
 {
    public static class ApiKeyAuthenticator
    {
-
       public static string GenerateSignature(string timestamp, string method, string url, string body, string appSecret)
       {
          return GetHMACInHex(appSecret, timestamp + method + url + body);
@@ -41,7 +40,10 @@ namespace Coinbase
          }
          return new string(c);
       }
+   }
 
+   public static class TimeHelper
+   {
       private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
       public static long GetCurrentUnixTimestampSeconds()

--- a/Source/Coinbase/Config.cs
+++ b/Source/Coinbase/Config.cs
@@ -1,3 +1,4 @@
+using Coinbase.Models;
 using System;
 
 namespace Coinbase
@@ -17,10 +18,15 @@ namespace Coinbase
    }
    public class OAuthConfig : Config
    {
-      public string OAuthToken { get; set; }
+      public string TokenEndpoint { get; set; } = CoinbaseApi.TokenEndpoint;
+        public string OAuthToken { get; set; }
+        public string RefreshToken { get; set; }
+        public Action<RefreshResponse> OnTokenRefresh { get; set; }
+
       internal override void EnsureValid()
       {
-         if (string.IsNullOrWhiteSpace(OAuthToken)) throw new ArgumentNullException(nameof(OAuthToken), "The OAuthToken must be specified.");
+         if (string.IsNullOrWhiteSpace(OAuthToken))
+                throw new ArgumentNullException(nameof(OAuthToken), "The OAuthToken must be specified.");
       }
    }
 

--- a/Source/Coinbase/Config.cs
+++ b/Source/Coinbase/Config.cs
@@ -1,5 +1,6 @@
 using Coinbase.Models;
 using System;
+using System.Threading.Tasks;
 
 namespace Coinbase
 {
@@ -21,7 +22,7 @@ namespace Coinbase
       public string TokenEndpoint { get; set; } = CoinbaseApi.TokenEndpoint;
         public string OAuthToken { get; set; }
         public string RefreshToken { get; set; }
-        public Action<RefreshResponse> OnTokenRefresh { get; set; }
+        public Func<RefreshResponse, Task> OnTokenRefresh { get; set; }
 
       internal override void EnsureValid()
       {

--- a/Source/Coinbase/Models/JsonResponse.cs
+++ b/Source/Coinbase/Models/JsonResponse.cs
@@ -14,6 +14,21 @@ namespace Coinbase.Models
       public IDictionary<string, JToken> ExtraJson { get; internal set; } = new Dictionary<string, JToken>();
    }
 
+    public class RefreshResponse
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+        [JsonProperty("expires_in")]
+        public int Expires { get; set; }
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+        [JsonProperty("created_at")]
+        public long Created { get; set; }
+   }
    public class JsonResponse : Json
    {
       /// <summary>
@@ -59,6 +74,12 @@ namespace Coinbase.Models
 
       [JsonProperty("data")]
       public T[] Data { get; set; }
+   }
+
+    public class ErrorResponse
+    {
+        [JsonProperty("errors")]
+        public Error[] Errors { get; set; }
    }
 
    public class Error : Json


### PR DESCRIPTION
Known issues: Request which cached the original token will throw revoked token exception
To fix this instead of globally adding the OAuth Header to the client, 
we should instead append the header using BeforeCallAsync, so if we update the AccessToken, other cached requests will not throw a revoked token exceotion
