### PR TITLE
Adding Auto Refresh Support

### DIFF
--- a/Source/Coinbase.Tests/Coinbase.Tests.csproj
+++ b/Source/Coinbase.Tests/Coinbase.Tests.csproj
@@ -74,7 +74,7 @@
     <Compile Include="CoinbaseApiKeyTests.cs" />
     <Compile Include="Endpoints\AccountTests.cs" />
     <Compile Include="Endpoints\NotificationTests.cs" />
-    <Compile Include="Endpoints\OAuthHelperTests.cs" />
+    <Compile Include="OAuthTests\OAuthHelperTests.cs" />
     <Compile Include="Integration\DataTests.cs" />
     <Compile Include="Endpoints\PaymentMethodTest.cs" />
     <Compile Include="Endpoints\WithdrawlTests.cs" />
@@ -86,6 +86,7 @@
     <Compile Include="Examples.cs" />
     <Compile Include="ExtensionsForTesting.cs" />
     <Compile Include="Integration\IntegrationTests.cs" />
+    <Compile Include="OAuthTests\TokenTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerTest.cs" />
     <Compile Include="Endpoints\UserTests.cs" />

--- a/Source/Coinbase.Tests/Examples.cs
+++ b/Source/Coinbase.Tests/Examples.cs
@@ -70,7 +70,7 @@ namespace Coinbase.Tests
                   "wallet:user:read",
                   "wallet:user:email"
                },
-         OauthMeta =  new Dictionary<string, JToken>()
+         OAuthMeta =  new Dictionary<string, JToken>()
       };
 
       public const string Account1 = @"{

--- a/Source/Coinbase.Tests/Integration/IntegrationTests.cs
+++ b/Source/Coinbase.Tests/Integration/IntegrationTests.cs
@@ -98,8 +98,8 @@ namespace Coinbase.Tests.Integration
       [Test]
       public async Task run_expired_token()
       {
-         this.client = new CoinbaseClient(new OAuthConfig { AccessToken = secrets.OAuthAccessToken })
-            .WithAutomaticOAuthTokenRefresh(secrets.OAuthClientId, secrets.OAuthClientSecret, secrets.OAuthRefreshToken);
+         this.client = new CoinbaseClient(new OAuthConfig { AccessToken = secrets.OAuthAccessToken, RefreshToken = secrets.OAuthRefreshToken })
+            .WithAutomaticOAuthTokenRefresh(secrets.OAuthClientId, secrets.OAuthClientSecret);
 
          var authInfo = await this.client.Users.GetAuthInfoAsync();
          authInfo.Dump();

--- a/Source/Coinbase.Tests/OAuthTests/OAuthHelperTests.cs
+++ b/Source/Coinbase.Tests/OAuthTests/OAuthHelperTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -8,9 +7,8 @@ using Flurl;
 using Flurl.Http;
 using Flurl.Http.Testing;
 using NUnit.Framework;
-using Z.ExtensionMethods;
 
-namespace Coinbase.Tests.Endpoints
+namespace Coinbase.Tests.OAuthTests
 {
    public class OAuthHelperTests
    {

--- a/Source/Coinbase.Tests/OAuthTests/TokenTests.cs
+++ b/Source/Coinbase.Tests/OAuthTests/TokenTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Coinbase.Tests.OAuthTests
+{
+   public class TokenTests : OAuthServerTest
+   {
+
+      [Test]
+      public async Task auto_refresh_token()
+      {
+         //simulate the expired response.
+         var expiredResponse = @"{""errors"":[{""id"":""expired_token"",""message"":""The access token is expired""}]}";
+         server.RespondWith(expiredResponse, status:401);
+
+
+         //simulate the refresh response.
+         var refreshResponse = @"{
+""access_token"":""aaa"",
+""token_type"":""bearer"",
+""expires_in"":7200,
+""refresh_token"":""bbb"",
+""scope"":""all"",
+""created_at"":1542649114
+}";
+         server.RespondWith(refreshResponse, status: 200);
+
+         //simulate the actual successful response after token refresh.
+         SetupServerSingleResponse(Examples.User);
+
+         //enable automatic refresh
+         client.WithAutomaticOAuthTokenRefresh("clientId", "clientSecret");
+
+         var response = await client.Users.GetCurrentUserAsync();
+
+         response.Dump();
+
+         var config = client.Config as OAuthConfig;
+         config.AccessToken.Should().Be("aaa");
+         config.RefreshToken.Should().Be("bbb");
+
+         Examples.UserModel.Should().BeEquivalentTo(response.Data);
+      }
+
+      [Test]
+      public async Task auto_refresh_token_with_callback()
+      {
+         //simulate the expired response.
+         var expiredResponse = @"{""errors"":[{""id"":""expired_token"",""message"":""The access token is expired""}]}";
+         server.RespondWith(expiredResponse, status: 401);
+
+         //simulate the refresh response.
+         var refreshResponse = @"{
+""access_token"":""aaa"",
+""token_type"":""bearer"",
+""expires_in"":7200,
+""refresh_token"":""bbb"",
+""scope"":""all"",
+""created_at"":1542649114
+}";
+         server.RespondWith(refreshResponse, status: 200);
+
+         //simulate the actual successful response after token refresh.
+         SetupServerSingleResponse(Examples.User);
+
+         //enable automatic refresh
+         client.WithAutomaticOAuthTokenRefresh("clientId", "clientSecret", o =>
+            {
+               o.AccessToken.Should().Be("aaa");
+               o.RefreshToken.Should().Be("bbb");
+               return Task.FromResult(0);
+            });
+
+         var response = await client.Users.GetCurrentUserAsync();
+
+         response.Dump();
+
+         var config = client.Config as OAuthConfig;
+         config.AccessToken.Should().Be("aaa");
+         config.RefreshToken.Should().Be("bbb");
+
+         Examples.UserModel.Should().BeEquivalentTo(response.Data);
+      }
+
+   }
+}

--- a/Source/Coinbase/CoinbaseClient.OAuth.cs
+++ b/Source/Coinbase/CoinbaseClient.OAuth.cs
@@ -188,9 +188,17 @@ namespace Coinbase
    {
       public const string ExpiredToken = "expired_token";
 
-        public static CoinbaseClient WithAutomaticOAuthTokenRefresh(this CoinbaseClient client, string clientId, string clientSecret, Func<OAuthResponse, Task> onRefresh = null)
+      /// <summary>
+      /// Setup the CoinbaseClient to use automatic token refresh.
+      /// </summary>
+      /// <param name="clientId">The OAuth Application Client ID</param>
+      /// <param name="clientSecret">The OAuth Application Secret</param>
+      /// <param name="onRefresh">Callback function to invoke when the OAuth token is refreshed.</param>
+      public static CoinbaseClient WithAutomaticOAuthTokenRefresh(this CoinbaseClient client, string clientId, string clientSecret, Func<OAuthResponse, Task> onRefresh = null)
       {
-         if (client.Config is OAuthConfig config) { }
+         if( client.Config is OAuthConfig config )
+         {
+         }
          else throw new InvalidOperationException($"Client must be using an {nameof(OAuthConfig)}");
 
          async Task TokenExpiredErrorHandler(HttpCall call)
@@ -204,7 +212,12 @@ namespace Coinbase
                   var refreshResponse = await OAuthHelper.RenewAccessAsync(config.RefreshToken, clientId, clientSecret).ConfigureAwait(false);
                   config.AccessToken = refreshResponse.AccessToken;
                   config.RefreshToken = refreshResponse.RefreshToken;
-                  await onRefresh?.Invoke(refreshResponse);
+
+                  if( onRefresh is null )
+                  {
+                  }
+                  else await onRefresh(refreshResponse).ConfigureAwait(false);
+
                   call.Response = await call.FlurlRequest.SendAsync(call.Request.Method, call.Request.Content).ConfigureAwait(false);
                   call.ExceptionHandled = true;
                }

--- a/Source/Coinbase/CoinbaseClient.cs
+++ b/Source/Coinbase/CoinbaseClient.cs
@@ -41,16 +41,10 @@ namespace Coinbase
       protected internal Url TimeEndpoint => this.Config.ApiUrl.AppendPathSegment("time");
       protected internal Url NotificationsEndpoint => this.Config.ApiUrl.AppendPathSegment("notifications");
 
-      public CoinbaseClient(OAuthConfig config): this(config as Config){}
-
-      public CoinbaseClient(ApiKeyConfig config) : this(config as Config){}
-
-      public CoinbaseClient() : this(null as Config){}
-
       /// <summary>
       /// The main class for making Coinbase API calls.
       /// </summary>
-      protected CoinbaseClient(Config config)
+      public CoinbaseClient(Config config = null)
       {
          this.Config = config ?? new Config();
          this.Config.EnsureValid();

--- a/Source/Coinbase/Config.cs
+++ b/Source/Coinbase/Config.cs
@@ -32,6 +32,7 @@ namespace Coinbase
    public class OAuthConfig : Config
    {
       public string AccessToken { get; set; }
+      public string RefreshToken { get; set; }
 
       internal override void EnsureValid()
       {

--- a/Source/Coinbase/Models/Objects.cs
+++ b/Source/Coinbase/Models/Objects.cs
@@ -469,7 +469,7 @@ namespace Coinbase.Models
       public string[] Scopes { get; set; }
 
       [JsonProperty("oauth_meta")]
-      public IDictionary<string, JToken> OauthMeta { get; set; }
+      public IDictionary<string, JToken> OAuthMeta { get; set; }
    }
 
 


### PR DESCRIPTION
Adding Support so Refresh tokens will work fluidly.
There was no way prior to get the refreshed token, so after the  first refresh you wouldn't be able to refresh again.

Additionally removing extra constructors that are now obsolete now that all of the configuration logic is done by the config class