### PR TITLE
Fixes #59

### DIFF
--- a/Source/Coinbase/Models/Objects.cs
+++ b/Source/Coinbase/Models/Objects.cs
@@ -429,7 +429,7 @@ namespace Coinbase.Models
    public partial class Money : Json
    {
       [JsonProperty("amount")]
-      public decimal Amount { get; set; }
+      public double Amount { get; set; }
 
       [JsonProperty("currency")]
       public string Currency { get; set; }


### PR DESCRIPTION
Made the Amount type in the Money class to be a double instead of a decimal, for more floating-point precision on cryptocurrency amounts.